### PR TITLE
Add ability to describe tool parameters via `#[ToolParameter]` attribute

### DIFF
--- a/src/ToolBox/Attribute/ToolParameter.php
+++ b/src/ToolBox/Attribute/ToolParameter.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\ToolBox\Attribute;
+
+use Webmozart\Assert\Assert;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class ToolParameter
+{
+    /**
+     * @param string[]|null            $enum
+     * @param string|int|string[]|null $const
+     */
+    public function __construct(
+        // can be used by many types
+        public ?array $enum = null,
+        public string|int|array|null $const = null,
+
+        // string
+        public ?string $pattern = null,
+        public ?int $minLength = null,
+        public ?int $maxLength = null,
+
+        // integer
+        public ?int $minimum = null,
+        public ?int $maximum = null,
+        public ?int $multipleOf = null,
+        public ?int $exclusiveMinimum = null,
+        public ?int $exclusiveMaximum = null,
+
+        // array
+        public ?int $minItems = null,
+        public ?int $maxItems = null,
+        public ?bool $uniqueItems = null,
+        public ?int $minContains = null,
+        public ?int $maxContains = null,
+
+        // object
+        public ?bool $required = null,
+        public ?int $minProperties = null,
+        public ?int $maxProperties = null,
+        public ?bool $dependentRequired = null,
+    ) {
+        if (is_array($enum)) {
+            Assert::allString($enum);
+        }
+
+        if (is_string($const)) {
+            Assert::stringNotEmpty(trim($const));
+        }
+
+        if (is_string($pattern)) {
+            Assert::stringNotEmpty(trim($pattern));
+        }
+
+        if (is_int($minLength)) {
+            Assert::greaterThanEq($minLength, 0);
+
+            if (is_int($maxLength)) {
+                Assert::greaterThanEq($maxLength, $minLength);
+            }
+        }
+
+        if (is_int($maxLength)) {
+            Assert::greaterThanEq($maxLength, 0);
+        }
+
+        if (is_int($minimum)) {
+            Assert::greaterThanEq($minimum, 0);
+
+            if (is_int($maximum)) {
+                Assert::greaterThanEq($maximum, $minimum);
+            }
+        }
+
+        if (is_int($maximum)) {
+            Assert::greaterThanEq($maximum, 0);
+        }
+
+        if (is_int($multipleOf)) {
+            Assert::greaterThanEq($multipleOf, 0);
+        }
+
+        if (is_int($exclusiveMinimum)) {
+            Assert::greaterThanEq($exclusiveMinimum, 0);
+
+            if (is_int($exclusiveMaximum)) {
+                Assert::greaterThanEq($exclusiveMaximum, $exclusiveMinimum);
+            }
+        }
+
+        if (is_int($exclusiveMaximum)) {
+            Assert::greaterThanEq($exclusiveMaximum, 0);
+        }
+
+        if (is_int($minItems)) {
+            Assert::greaterThanEq($minItems, 0);
+
+            if (is_int($maxItems)) {
+                Assert::greaterThanEq($maxItems, $minItems);
+            }
+        }
+
+        if (is_int($maxItems)) {
+            Assert::greaterThanEq($maxItems, 0);
+        }
+
+        if (is_bool($uniqueItems)) {
+            Assert::true($uniqueItems);
+        }
+
+        if (is_int($minContains)) {
+            Assert::greaterThanEq($minContains, 0);
+
+            if (is_int($maxContains)) {
+                Assert::greaterThanEq($maxContains, $minContains);
+            }
+        }
+
+        if (is_int($maxContains)) {
+            Assert::greaterThanEq($maxContains, 0);
+        }
+
+        if (is_int($minProperties)) {
+            Assert::greaterThanEq($minProperties, 0);
+
+            if (is_int($maxProperties)) {
+                Assert::greaterThanEq($maxProperties, $minProperties);
+            }
+        }
+
+        if (is_int($maxProperties)) {
+            Assert::greaterThanEq($maxProperties, 0);
+        }
+    }
+}

--- a/tests/ToolBox/Attribute/ToolParameterTest.php
+++ b/tests/ToolBox/Attribute/ToolParameterTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\ToolBox\Attribute;
+
+use PhpLlm\LlmChain\ToolBox\Attribute\ToolParameter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+#[CoversClass(ToolParameter::class)]
+final class ToolParameterTest extends TestCase
+{
+    public function testValidEnum(): void
+    {
+        $enum = ['value1', 'value2'];
+        $toolParameter = new ToolParameter(enum: $enum);
+        $this->assertSame($enum, $toolParameter->enum);
+    }
+
+    public function testInvalidEnumContainsNonString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $enum = ['value1', 2];
+        new ToolParameter(enum: $enum);
+    }
+
+    public function testValidConstString(): void
+    {
+        $const = 'constant value';
+        $toolParameter = new ToolParameter(const: $const);
+        $this->assertSame($const, $toolParameter->const);
+    }
+
+    public function testInvalidConstEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $const = '   ';
+        new ToolParameter(const: $const);
+    }
+
+    public function testValidPattern(): void
+    {
+        $pattern = '/^[a-z]+$/';
+        $toolParameter = new ToolParameter(pattern: $pattern);
+        $this->assertSame($pattern, $toolParameter->pattern);
+    }
+
+    public function testInvalidPatternEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $pattern = '   ';
+        new ToolParameter(pattern: $pattern);
+    }
+
+    public function testValidMinLength(): void
+    {
+        $minLength = 5;
+        $toolParameter = new ToolParameter(minLength: $minLength);
+        $this->assertSame($minLength, $toolParameter->minLength);
+    }
+
+    public function testInvalidMinLengthNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minLength: -1);
+    }
+
+    public function testValidMinLengthAndMaxLength(): void
+    {
+        $minLength = 5;
+        $maxLength = 10;
+        $toolParameter = new ToolParameter(minLength: $minLength, maxLength: $maxLength);
+        $this->assertSame($minLength, $toolParameter->minLength);
+        $this->assertSame($maxLength, $toolParameter->maxLength);
+    }
+
+    public function testInvalidMaxLengthLessThanMinLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minLength: 10, maxLength: 5);
+    }
+
+    public function testValidMinimum(): void
+    {
+        $minimum = 0;
+        $toolParameter = new ToolParameter(minimum: $minimum);
+        $this->assertSame($minimum, $toolParameter->minimum);
+    }
+
+    public function testInvalidMinimumNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minimum: -1);
+    }
+
+    public function testValidMultipleOf(): void
+    {
+        $multipleOf = 5;
+        $toolParameter = new ToolParameter(multipleOf: $multipleOf);
+        $this->assertSame($multipleOf, $toolParameter->multipleOf);
+    }
+
+    public function testInvalidMultipleOfNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(multipleOf: -5);
+    }
+
+    public function testValidExclusiveMinimumAndMaximum(): void
+    {
+        $exclusiveMinimum = 1;
+        $exclusiveMaximum = 10;
+        $toolParameter = new ToolParameter(exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum);
+        $this->assertSame($exclusiveMinimum, $toolParameter->exclusiveMinimum);
+        $this->assertSame($exclusiveMaximum, $toolParameter->exclusiveMaximum);
+    }
+
+    public function testInvalidExclusiveMaximumLessThanExclusiveMinimum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(exclusiveMinimum: 10, exclusiveMaximum: 5);
+    }
+
+    public function testValidMinItemsAndMaxItems(): void
+    {
+        $minItems = 1;
+        $maxItems = 5;
+        $toolParameter = new ToolParameter(minItems: $minItems, maxItems: $maxItems);
+        $this->assertSame($minItems, $toolParameter->minItems);
+        $this->assertSame($maxItems, $toolParameter->maxItems);
+    }
+
+    public function testInvalidMaxItemsLessThanMinItems(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minItems: 5, maxItems: 1);
+    }
+
+    public function testValidUniqueItemsTrue(): void
+    {
+        $toolParameter = new ToolParameter(uniqueItems: true);
+        $this->assertTrue($toolParameter->uniqueItems);
+    }
+
+    public function testInvalidUniqueItemsFalse(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(uniqueItems: false);
+    }
+
+    public function testValidMinContainsAndMaxContains(): void
+    {
+        $minContains = 1;
+        $maxContains = 3;
+        $toolParameter = new ToolParameter(minContains: $minContains, maxContains: $maxContains);
+        $this->assertSame($minContains, $toolParameter->minContains);
+        $this->assertSame($maxContains, $toolParameter->maxContains);
+    }
+
+    public function testInvalidMaxContainsLessThanMinContains(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minContains: 3, maxContains: 1);
+    }
+
+    public function testValidRequired(): void
+    {
+        $toolParameter = new ToolParameter(required: true);
+        $this->assertTrue($toolParameter->required);
+    }
+
+    public function testValidMinPropertiesAndMaxProperties(): void
+    {
+        $minProperties = 1;
+        $maxProperties = 5;
+        $toolParameter = new ToolParameter(minProperties: $minProperties, maxProperties: $maxProperties);
+        $this->assertSame($minProperties, $toolParameter->minProperties);
+        $this->assertSame($maxProperties, $toolParameter->maxProperties);
+    }
+
+    public function testInvalidMaxPropertiesLessThanMinProperties(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minProperties: 5, maxProperties: 1);
+    }
+
+    public function testValidDependentRequired(): void
+    {
+        $toolParameter = new ToolParameter(dependentRequired: true);
+        $this->assertTrue($toolParameter->dependentRequired);
+    }
+
+    public function testValidCombination(): void
+    {
+        $toolParameter = new ToolParameter(
+            enum: ['value1', 'value2'],
+            const: 'constant',
+            pattern: '/^[a-z]+$/',
+            minLength: 5,
+            maxLength: 10,
+            minimum: 0,
+            maximum: 100,
+            multipleOf: 5,
+            exclusiveMinimum: 1,
+            exclusiveMaximum: 99,
+            minItems: 1,
+            maxItems: 10,
+            uniqueItems: true,
+            minContains: 1,
+            maxContains: 5,
+            required: true,
+            minProperties: 1,
+            maxProperties: 5,
+            dependentRequired: true
+        );
+
+        $this->assertInstanceOf(ToolParameter::class, $toolParameter);
+    }
+
+    public function testInvalidCombination(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ToolParameter(minLength: -1, maxLength: -2);
+    }
+}

--- a/tests/ToolBox/Attribute/ToolParameterTest.php
+++ b/tests/ToolBox/Attribute/ToolParameterTest.php
@@ -6,68 +6,78 @@ namespace PhpLlm\LlmChain\Tests\ToolBox\Attribute;
 
 use PhpLlm\LlmChain\ToolBox\Attribute\ToolParameter;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\InvalidArgumentException;
 
 #[CoversClass(ToolParameter::class)]
 final class ToolParameterTest extends TestCase
 {
-    public function testValidEnum(): void
+    #[Test]
+    public function validEnum(): void
     {
         $enum = ['value1', 'value2'];
         $toolParameter = new ToolParameter(enum: $enum);
         $this->assertSame($enum, $toolParameter->enum);
     }
 
-    public function testInvalidEnumContainsNonString(): void
+    #[Test]
+    public function invalidEnumContainsNonString(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $enum = ['value1', 2];
         new ToolParameter(enum: $enum);
     }
 
-    public function testValidConstString(): void
+    #[Test]
+    public function validConstString(): void
     {
         $const = 'constant value';
         $toolParameter = new ToolParameter(const: $const);
         $this->assertSame($const, $toolParameter->const);
     }
 
-    public function testInvalidConstEmptyString(): void
+    #[Test]
+    public function invalidConstEmptyString(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $const = '   ';
         new ToolParameter(const: $const);
     }
 
-    public function testValidPattern(): void
+    #[Test]
+    public function validPattern(): void
     {
         $pattern = '/^[a-z]+$/';
         $toolParameter = new ToolParameter(pattern: $pattern);
         $this->assertSame($pattern, $toolParameter->pattern);
     }
 
-    public function testInvalidPatternEmptyString(): void
+    #[Test]
+    public function invalidPatternEmptyString(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $pattern = '   ';
         new ToolParameter(pattern: $pattern);
     }
 
-    public function testValidMinLength(): void
+    #[Test]
+    public function validMinLength(): void
     {
         $minLength = 5;
         $toolParameter = new ToolParameter(minLength: $minLength);
         $this->assertSame($minLength, $toolParameter->minLength);
     }
 
-    public function testInvalidMinLengthNegative(): void
+    #[Test]
+    public function invalidMinLengthNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minLength: -1);
     }
 
-    public function testValidMinLengthAndMaxLength(): void
+    #[Test]
+    public function validMinLengthAndMaxLength(): void
     {
         $minLength = 5;
         $maxLength = 10;
@@ -76,39 +86,45 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxLength, $toolParameter->maxLength);
     }
 
-    public function testInvalidMaxLengthLessThanMinLength(): void
+    #[Test]
+    public function invalidMaxLengthLessThanMinLength(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minLength: 10, maxLength: 5);
     }
 
-    public function testValidMinimum(): void
+    #[Test]
+    public function validMinimum(): void
     {
         $minimum = 0;
         $toolParameter = new ToolParameter(minimum: $minimum);
         $this->assertSame($minimum, $toolParameter->minimum);
     }
 
-    public function testInvalidMinimumNegative(): void
+    #[Test]
+    public function invalidMinimumNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minimum: -1);
     }
 
-    public function testValidMultipleOf(): void
+    #[Test]
+    public function validMultipleOf(): void
     {
         $multipleOf = 5;
         $toolParameter = new ToolParameter(multipleOf: $multipleOf);
         $this->assertSame($multipleOf, $toolParameter->multipleOf);
     }
 
-    public function testInvalidMultipleOfNegative(): void
+    #[Test]
+    public function invalidMultipleOfNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(multipleOf: -5);
     }
 
-    public function testValidExclusiveMinimumAndMaximum(): void
+    #[Test]
+    public function validExclusiveMinimumAndMaximum(): void
     {
         $exclusiveMinimum = 1;
         $exclusiveMaximum = 10;
@@ -117,13 +133,15 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($exclusiveMaximum, $toolParameter->exclusiveMaximum);
     }
 
-    public function testInvalidExclusiveMaximumLessThanExclusiveMinimum(): void
+    #[Test]
+    public function invalidExclusiveMaximumLessThanExclusiveMinimum(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(exclusiveMinimum: 10, exclusiveMaximum: 5);
     }
 
-    public function testValidMinItemsAndMaxItems(): void
+    #[Test]
+    public function validMinItemsAndMaxItems(): void
     {
         $minItems = 1;
         $maxItems = 5;
@@ -132,25 +150,29 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxItems, $toolParameter->maxItems);
     }
 
-    public function testInvalidMaxItemsLessThanMinItems(): void
+    #[Test]
+    public function invalidMaxItemsLessThanMinItems(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minItems: 5, maxItems: 1);
     }
 
-    public function testValidUniqueItemsTrue(): void
+    #[Test]
+    public function validUniqueItemsTrue(): void
     {
         $toolParameter = new ToolParameter(uniqueItems: true);
         $this->assertTrue($toolParameter->uniqueItems);
     }
 
-    public function testInvalidUniqueItemsFalse(): void
+    #[Test]
+    public function invalidUniqueItemsFalse(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(uniqueItems: false);
     }
 
-    public function testValidMinContainsAndMaxContains(): void
+    #[Test]
+    public function validMinContainsAndMaxContains(): void
     {
         $minContains = 1;
         $maxContains = 3;
@@ -159,19 +181,22 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxContains, $toolParameter->maxContains);
     }
 
-    public function testInvalidMaxContainsLessThanMinContains(): void
+    #[Test]
+    public function invalidMaxContainsLessThanMinContains(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minContains: 3, maxContains: 1);
     }
 
-    public function testValidRequired(): void
+    #[Test]
+    public function validRequired(): void
     {
         $toolParameter = new ToolParameter(required: true);
         $this->assertTrue($toolParameter->required);
     }
 
-    public function testValidMinPropertiesAndMaxProperties(): void
+    #[Test]
+    public function validMinPropertiesAndMaxProperties(): void
     {
         $minProperties = 1;
         $maxProperties = 5;
@@ -180,19 +205,22 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxProperties, $toolParameter->maxProperties);
     }
 
-    public function testInvalidMaxPropertiesLessThanMinProperties(): void
+    #[Test]
+    public function invalidMaxPropertiesLessThanMinProperties(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minProperties: 5, maxProperties: 1);
     }
 
-    public function testValidDependentRequired(): void
+    #[Test]
+    public function validDependentRequired(): void
     {
         $toolParameter = new ToolParameter(dependentRequired: true);
         $this->assertTrue($toolParameter->dependentRequired);
     }
 
-    public function testValidCombination(): void
+    #[Test]
+    public function validCombination(): void
     {
         $toolParameter = new ToolParameter(
             enum: ['value1', 'value2'],
@@ -219,7 +247,8 @@ final class ToolParameterTest extends TestCase
         $this->assertInstanceOf(ToolParameter::class, $toolParameter);
     }
 
-    public function testInvalidCombination(): void
+    #[Test]
+    public function invalidCombination(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new ToolParameter(minLength: -1, maxLength: -2);

--- a/tests/ToolBox/ParameterAnalyzerTest.php
+++ b/tests/ToolBox/ParameterAnalyzerTest.php
@@ -7,6 +7,7 @@ namespace PhpLlm\LlmChain\Tests\ToolBox;
 use PhpLlm\LlmChain\Tests\ToolBox\Tool\ToolNoParams;
 use PhpLlm\LlmChain\Tests\ToolBox\Tool\ToolOptionalParam;
 use PhpLlm\LlmChain\Tests\ToolBox\Tool\ToolRequiredParams;
+use PhpLlm\LlmChain\Tests\ToolBox\Tool\ToolWithToolParameterAttribute;
 use PhpLlm\LlmChain\ToolBox\AsTool;
 use PhpLlm\LlmChain\ToolBox\Metadata;
 use PhpLlm\LlmChain\ToolBox\ParameterAnalyzer;
@@ -47,6 +48,82 @@ final class ParameterAnalyzerTest extends TestCase
             'required' => [
                 'text',
                 'number',
+            ],
+        ];
+
+        self::assertSame($expected, $actual);
+    }
+
+    #[Test]
+    public function detectParameterDefinitionRequiredWithAdditionalToolParameterAttribute(): void
+    {
+        $actual = $this->analyzer->getDefinition(ToolWithToolParameterAttribute::class, '__invoke');
+        $expected = [
+            'type' => 'object',
+            'properties' => [
+                'animal' => [
+                    'type' => 'string',
+                    'description' => 'The animal given to the tool',
+                    'enum' => ['dog', 'cat', 'bird'],
+                ],
+                'numberOfArticles' => [
+                    'type' => 'integer',
+                    'description' => 'The number of articles given to the tool',
+                    'const' => 42,
+                ],
+                'infoEmail' => [
+                    'type' => 'string',
+                    'description' => 'The info email given to the tool',
+                    'const' => 'info@example.de',
+                ],
+                'locales' => [
+                    'type' => 'string',
+                    'description' => 'The locales given to the tool',
+                    'const' => ['de', 'en'],
+                ],
+                'text' => [
+                    'type' => 'string',
+                    'description' => 'The text given to the tool',
+                    'pattern' => '^[a-zA-Z]+$',
+                    'minLength' => 1,
+                    'maxLength' => 10,
+                ],
+                'number' => [
+                    'type' => 'integer',
+                    'description' => 'The number given to the tool',
+                    'minimum' => 1,
+                    'maximum' => 10,
+                    'multipleOf' => 2,
+                    'exclusiveMinimum' => 1,
+                    'exclusiveMaximum' => 10,
+                ],
+                'products' => [
+                    'type' => 'array',
+                    'description' => 'The products given to the tool',
+                    'minItems' => 1,
+                    'maxItems' => 10,
+                    'uniqueItems' => true,
+                    'minContains' => 1,
+                    'maxContains' => 10,
+                ],
+                'shippingAddress' => [
+                    'type' => 'object',
+                    'description' => 'The shipping address given to the tool',
+                    'required' => true,
+                    'minProperties' => 1,
+                    'maxProperties' => 10,
+                    'dependentRequired' => true,
+                ],
+            ],
+            'required' => [
+                'animal',
+                'numberOfArticles',
+                'infoEmail',
+                'locales',
+                'text',
+                'number',
+                'products',
+                'shippingAddress',
             ],
         ];
 

--- a/tests/ToolBox/Tool/ToolWithToolParameterAttribute.php
+++ b/tests/ToolBox/Tool/ToolWithToolParameterAttribute.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\ToolBox\Tool;
+
+use PhpLlm\LlmChain\ToolBox\AsTool;
+use PhpLlm\LlmChain\ToolBox\Attribute\ToolParameter;
+
+#[AsTool('tool_with_ToolParameter_attribute', 'A tool which has a parameter with described with #[ToolParameter] attribute')]
+final class ToolWithToolParameterAttribute
+{
+    /**
+     * @param string $animal           The animal given to the tool
+     * @param int    $numberOfArticles The number of articles given to the tool
+     * @param string $infoEmail        The info email given to the tool
+     * @param string $locales          The locales given to the tool
+     * @param string $text             The text given to the tool
+     * @param int    $number           The number given to the tool
+     * @param array  $products         The products given to the tool
+     * @param object $shippingAddress  The shipping address given to the tool
+     */
+    public function __invoke(
+        #[ToolParameter(
+            enum: ['dog', 'cat', 'bird'],
+        )]
+        string $animal,
+        #[ToolParameter(
+            const: 42,
+        )]
+        int $numberOfArticles,
+        #[ToolParameter(
+            const: 'info@example.de',
+        )]
+        string $infoEmail,
+        #[ToolParameter(
+            const: ['de', 'en'],
+        )]
+        string $locales,
+        #[ToolParameter(
+            pattern: '^[a-zA-Z]+$',
+            minLength: 1,
+            maxLength: 10,
+        )]
+        string $text,
+        #[ToolParameter(
+            minimum: 1,
+            maximum: 10,
+            multipleOf: 2,
+            exclusiveMinimum: 1,
+            exclusiveMaximum: 10,
+        )]
+        int $number,
+        #[ToolParameter(
+            minItems: 1,
+            maxItems: 10,
+            uniqueItems: true,
+            minContains: 1,
+            maxContains: 10,
+        )]
+        array $products,
+        #[ToolParameter(
+            required: true,
+            minProperties: 1,
+            maxProperties: 10,
+            dependentRequired: true,
+        )]
+        object $shippingAddress,
+    ): string {
+        return implode(
+            ', ',
+            [
+                $text,
+                $number,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Todo

validate, that this is not allowed:
```php
#[ToolParameter(const: 'my-string')]
int $number
```