### PR TITLE
[BC Break] Require `Document::$text` contains non empty string and simplify `Document` API

### DIFF
--- a/examples/store-mongodb-similarity-search.php
+++ b/examples/store-mongodb-similarity-search.php
@@ -46,9 +46,10 @@ $movies = [
 
 // create embeddings and documents
 foreach ($movies as $movie) {
-    $documents[] = Document::fromText(
+    $documents[] = new Document(
         id: Uuid::v4(),
         text: $movie['title'].' '.$movie['description'],
+        vector: null,
         metadata: new Metadata($movie),
     );
 }

--- a/examples/store-pinecone-similarity-search.php
+++ b/examples/store-pinecone-similarity-search.php
@@ -40,9 +40,10 @@ $movies = [
 
 // create embeddings and documents
 foreach ($movies as $movie) {
-    $documents[] = Document::fromText(
+    $documents[] = new Document(
         id: Uuid::v4(),
         text: 'Title: '.$movie['title'].PHP_EOL.'Director: '.$movie['director'].PHP_EOL.$movie['description'],
+        vector: null,
         metadata: new Metadata($movie),
     );
 }

--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -5,51 +5,17 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Document;
 
 use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Uid\UuidV4;
+use Webmozart\Assert\Assert;
 
 final readonly class Document
 {
     public function __construct(
         public Uuid $id,
-        public ?string $text,
+        public string $text,
         public ?Vector $vector,
         public Metadata $metadata = new Metadata([]),
     ) {
-    }
-
-    public static function fromText(string $text, Uuid $id = new UuidV4(), Metadata $metadata = new Metadata([])): self
-    {
-        return new self(
-            $id,
-            $text,
-            null,
-            $metadata,
-        );
-    }
-
-    public static function fromVector(Vector $vector, Uuid $id = new UuidV4(), Metadata $metadata = new Metadata([])): self
-    {
-        return new self(
-            $id,
-            null,
-            $vector,
-            $metadata,
-        );
-    }
-
-    public function withText(string $text): self
-    {
-        return new self(
-            $this->id,
-            $text,
-            $this->vector,
-            $this->metadata,
-        );
-    }
-
-    public function hasText(): bool
-    {
-        return null !== $this->text;
+        Assert::stringNotEmpty(trim($this->text));
     }
 
     public function withVector(Vector $vector): self

--- a/src/DocumentEmbedder.php
+++ b/src/DocumentEmbedder.php
@@ -33,9 +33,6 @@ final readonly class DocumentEmbedder
             $documents = [$documents];
         }
 
-        // Filter out documents without text
-        $documents = array_filter($documents, fn (Document $document) => is_string($document->text));
-
         if ([] === $documents) {
             $this->logger->debug('No documents to embed');
 

--- a/src/Store/Azure/SearchStore.php
+++ b/src/Store/Azure/SearchStore.php
@@ -78,6 +78,7 @@ final readonly class SearchStore implements VectorStoreInterface
         return array_merge([
             'id' => $document->id,
             $this->vectorFieldName => $document->vector->getData(),
+            'text' => $document->text,
         ], $document->metadata->getArrayCopy());
     }
 
@@ -88,8 +89,8 @@ final readonly class SearchStore implements VectorStoreInterface
     {
         return new Document(
             id: Uuid::fromString($data['id']),
-            text: null,
-            vector: null,
+            text: $data['text'],
+            vector: $data[$this->vectorFieldName] ? new Vector($data[$this->vectorFieldName]) : null,
             metadata: new Metadata($data),
         );
     }

--- a/src/Store/ChromaDB/Store.php
+++ b/src/Store/ChromaDB/Store.php
@@ -55,10 +55,11 @@ final readonly class Store implements VectorStoreInterface
 
         $documents = [];
         for ($i = 0; $i < count($queryResponse->metadatas[0]); ++$i) {
-            $documents[] = Document::fromVector(
-                new Vector($queryResponse->embeddings[0][$i]),
-                Uuid::fromString($queryResponse->ids[0][$i]),
-                new Metadata($queryResponse->metadatas[0][$i]),
+            $documents[] = new Document( // not sure how to insert and get the text here @chr-hertel
+                id: Uuid::fromString($queryResponse->ids[0][$i]),
+                text: '???',
+                vector: new Vector($queryResponse->embeddings[0][$i]),
+                metadata: new Metadata($queryResponse->metadatas[0][$i]),
             );
         }
 

--- a/src/Store/ChromaDB/Store.php
+++ b/src/Store/ChromaDB/Store.php
@@ -55,7 +55,7 @@ final readonly class Store implements VectorStoreInterface
 
         $documents = [];
         for ($i = 0; $i < count($queryResponse->metadatas[0]); ++$i) {
-            $documents[] = new Document( // not sure how to insert and get the text here @chr-hertel
+            $documents[] = new Document(
                 id: Uuid::fromString($queryResponse->ids[0][$i]),
                 text: '???',
                 vector: new Vector($queryResponse->embeddings[0][$i]),

--- a/src/Store/MongoDB/Store.php
+++ b/src/Store/MongoDB/Store.php
@@ -129,10 +129,11 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         $documents = [];
 
         foreach ($results as $result) {
-            $documents[] = Document::fromVector(
-                new Vector($result[$this->vectorFieldName]),
-                $this->toUuid($result['_id']),
-                new Metadata($result['metadata'] ?? []),
+            $documents[] = new Document(
+                id: $this->toUuid($result['_id']),
+                text: $result['text'],
+                vector: new Vector($result[$this->vectorFieldName]),
+                metadata: new Metadata($result['metadata'] ?? []),
             );
         }
 

--- a/src/Store/Pinecone/Store.php
+++ b/src/Store/Pinecone/Store.php
@@ -45,6 +45,7 @@ final readonly class Store implements VectorStoreInterface
             $vectors[] = [
                 'id' => (string) $document->id,
                 'values' => $document->vector->getData(),
+                'text' => $document->text,
                 'metadata' => $document->metadata->getArrayCopy(),
             ];
         }
@@ -68,10 +69,11 @@ final readonly class Store implements VectorStoreInterface
 
         $documents = [];
         foreach ($response->json()['matches'] as $match) {
-            $documents[] = Document::fromVector(
-                new Vector($match['values']),
-                Uuid::fromString($match['id']),
-                new Metadata($match['metadata']),
+            $documents[] = new Document(
+                id: Uuid::fromString($match['id']),
+                text: $match['text'],
+                vector: new Vector($match['values']),
+                metadata: new Metadata($match['metadata']),
             );
         }
 

--- a/tests/DocumentEmbedderTest.php
+++ b/tests/DocumentEmbedderTest.php
@@ -65,30 +65,11 @@ final class DocumentEmbedderTest extends TestCase
     }
 
     #[Test]
-    public function embedDocumentWithoutText(): void
-    {
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('debug')->with('No documents to embed');
-
-        $embedder = new DocumentEmbedder(
-            $embeddings = new TestEmbeddingsModel(),
-            $store = new TestStore(),
-            new MockClock(),
-            $logger,
-        );
-
-        $embedder->embed(new Document(Uuid::v4(), null, null));
-
-        self::assertSame(0, $embeddings->multiCreateCalls);
-        self::assertSame([], $store->documents);
-    }
-
-    #[Test]
     public function embedDocumentWithMetadata(): void
     {
         $vectorData = [0.1, 0.2, 0.3];
         $metadata = new Metadata(['key' => 'value']);
-        $document = Document::fromText('Test content', Uuid::v4(), $metadata);
+        $document = new Document(Uuid::v4(), 'Test content', null, $metadata);
 
         $embedder = new DocumentEmbedder(
             new TestEmbeddingsModel(multiCreate: [$vector = new Vector($vectorData)]),


### PR DESCRIPTION
I would do this as a first step before continuing in
* #85 

In the next step I would remove the `vector` property, so we always have a `Document` in a valid state and then create `EmbeddedDocument` class which extends `Document` and add the `vector` information.

With this change, a `Document` is always embeddable: Right now, this is not the case!