### PR TITLE
Introduce `NullVector` and `VectorInterface`

### DIFF
--- a/src/Document/NullVector.php
+++ b/src/Document/NullVector.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Document;
 
+use PhpLlm\LlmChain\Exception\RuntimeException;
+
 final class NullVector implements VectorInterface
 {
     public function getData(): array
     {
-        return [];
+        throw new RuntimeException('getData() method cannot be called on a NullVector.');
     }
 
     public function getDimensions(): int
     {
-        return 0;
+        throw new RuntimeException('getDimensions() method cannot be called on a NullVector.');
     }
-}

--- a/src/Document/NullVector.php
+++ b/src/Document/NullVector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Document;
+
+final class NullVector implements VectorInterface
+{
+    public function getData(): array
+    {
+        return [];
+    }
+
+    public function getDimensions(): int
+    {
+        return 0;
+    }
+}

--- a/src/Document/NullVector.php
+++ b/src/Document/NullVector.php
@@ -17,3 +17,4 @@ final class NullVector implements VectorInterface
     {
         throw new RuntimeException('getDimensions() method cannot be called on a NullVector.');
     }
+}

--- a/src/Document/Vector.php
+++ b/src/Document/Vector.php
@@ -6,7 +6,7 @@ namespace PhpLlm\LlmChain\Document;
 
 use PhpLlm\LlmChain\Exception\InvalidArgumentException;
 
-final class Vector
+final class Vector implements VectorInterface
 {
     /**
      * @param list<float> $data

--- a/src/Document/VectorDocument.php
+++ b/src/Document/VectorDocument.php
@@ -10,7 +10,7 @@ final readonly class VectorDocument
 {
     public function __construct(
         public Uuid $id,
-        public Vector $vector,
+        public VectorInterface $vector,
         public Metadata $metadata = new Metadata(),
     ) {
     }

--- a/src/Document/VectorInterface.php
+++ b/src/Document/VectorInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Document;
 
-use PhpLlm\LlmChain\Exception\InvalidArgumentException;
-
 interface VectorInterface
 {
     /**

--- a/src/Document/VectorInterface.php
+++ b/src/Document/VectorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Document;
+
+use PhpLlm\LlmChain\Exception\InvalidArgumentException;
+
+interface VectorInterface
+{
+    /**
+     * @return list<float>
+     */
+    public function getData(): array;
+
+    public function getDimensions(): int;
+}

--- a/src/Store/Azure/SearchStore.php
+++ b/src/Store/Azure/SearchStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Store\Azure;
 
 use PhpLlm\LlmChain\Document\Metadata;
+use PhpLlm\LlmChain\Document\NullVector;
 use PhpLlm\LlmChain\Document\Vector;
 use PhpLlm\LlmChain\Document\VectorDocument;
 use PhpLlm\LlmChain\Store\VectorStoreInterface;
@@ -80,7 +81,9 @@ final readonly class SearchStore implements VectorStoreInterface
     {
         return new VectorDocument(
             id: Uuid::fromString($data['id']),
-            vector: $data[$this->vectorFieldName] ? new Vector($data[$this->vectorFieldName]) : null,
+            vector: !array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
+                ? new NullVector()
+                : new Vector($data[$this->vectorFieldName]),
             metadata: new Metadata($data),
         );
     }

--- a/tests/Document/NullVectorTest.php
+++ b/tests/Document/NullVectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Document;
+
+use PhpLlm\LlmChain\Document\NullVector;
+use PhpLlm\LlmChain\Document\VectorInterface;
+use PhpLlm\LlmChain\Exception\RuntimeException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NullVector::class)]
+final class NullVectorTest extends TestCase
+{
+    #[Test]
+    public function implementsInterface(): void
+    {
+        self::assertInstanceOf(VectorInterface::class, new NullVector());
+    }
+
+    #[Test]
+    public function getDataThrowsOnAccess(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new NullVector())->getData();
+    }
+
+    #[Test]
+    public function getDimensionsThrowsOnAccess(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new NullVector())->getDimensions();
+    }
+}

--- a/tests/Document/VectorTest.php
+++ b/tests/Document/VectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Tests\Document;
 
 use PhpLlm\LlmChain\Document\Vector;
+use PhpLlm\LlmChain\Document\VectorInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -12,6 +13,15 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Vector::class)]
 final class VectorTest extends TestCase
 {
+    #[Test]
+    public function implementsInterface(): void
+    {
+        self::assertInstanceOf(
+            VectorInterface::class,
+            new Vector([1.0, 2.0, 3.0])
+        );
+    }
+
     #[Test]
     public function withDimensionNull(): void
     {


### PR DESCRIPTION
If it is not available, `null` is an invalid type for our `vector property`

![CleanShot 2024-10-04 at 10 27 38@2x](https://github.com/user-attachments/assets/6f7d7543-8b41-46dc-ac94-e232e6a0520b)
