### PR TITLE
feat: introduce chain awareness in chain processors to nest them

### DIFF
--- a/examples/structured-output-clock.php
+++ b/examples/structured-output-clock.php
@@ -1,0 +1,58 @@
+<?php
+
+use PhpLlm\LlmChain\Chain;
+use PhpLlm\LlmChain\Message\Message;
+use PhpLlm\LlmChain\Message\MessageBag;
+use PhpLlm\LlmChain\OpenAI\Model\Gpt;
+use PhpLlm\LlmChain\OpenAI\Model\Gpt\Version;
+use PhpLlm\LlmChain\OpenAI\Platform\OpenAI;
+use PhpLlm\LlmChain\StructuredOutput\ChainProcessor as StructuredOutputProcessor;
+use PhpLlm\LlmChain\StructuredOutput\ResponseFormatFactory;
+use PhpLlm\LlmChain\ToolBox\ChainProcessor as ToolProcessor;
+use PhpLlm\LlmChain\ToolBox\Tool\Clock;
+use PhpLlm\LlmChain\ToolBox\ToolAnalyzer;
+use PhpLlm\LlmChain\ToolBox\ToolBox;
+use Symfony\Component\Clock\Clock as SymfonyClock;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+
+if (empty($_ENV['OPENAI_API_KEY'])) {
+    echo 'Please set the OPENAI_API_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = new OpenAI(HttpClient::create(), $_ENV['OPENAI_API_KEY']);
+$llm = new Gpt($platform, Version::gpt4oMini());
+
+$clock = new Clock(new SymfonyClock());
+$toolBox = new ToolBox(new ToolAnalyzer(), [$clock]);
+$toolProcessor = new ToolProcessor($toolBox);
+$serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
+$structuredOutputProcessor = new StructuredOutputProcessor(new ResponseFormatFactory(), $serializer);
+$chain = new Chain($llm, [$toolProcessor, $structuredOutputProcessor], [$toolProcessor, $structuredOutputProcessor]);
+
+$messages = new MessageBag(Message::ofUser('What date and time is it?'));
+$response = $chain->call($messages, ['response_format' => [
+    'type' => 'json_schema',
+    'json_schema' => [
+        'name' => 'clock',
+        'strict' => true,
+        'schema' => [
+            'type' => 'object',
+            'properties' => [
+                'date' => ['type' => 'string', 'description' => 'The current date in the format YYYY-MM-DD.'],
+                'time' => ['type' => 'string', 'description' => 'The current time in the format HH:MM:SS.'],
+            ],
+            'required' => ['date', 'time'],
+            'additionalProperties' => false,
+        ],
+    ],
+]]);
+
+dump($response->getContent());

--- a/src/Chain/ChainAwareProcessor.php
+++ b/src/Chain/ChainAwareProcessor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Chain;
+
+use PhpLlm\LlmChain\Chain;
+
+interface ChainAwareProcessor
+{
+    public function setChain(Chain $chain): void;
+}

--- a/src/Chain/ChainAwareTrait.php
+++ b/src/Chain/ChainAwareTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Chain;
+
+use PhpLlm\LlmChain\Chain;
+
+trait ChainAwareTrait
+{
+    private Chain $chain;
+
+    public function setChain(Chain $chain): void
+    {
+        $this->chain = $chain;
+    }
+}

--- a/src/Chain/Output.php
+++ b/src/Chain/Output.php
@@ -8,16 +8,16 @@ use PhpLlm\LlmChain\LanguageModel;
 use PhpLlm\LlmChain\Message\MessageBag;
 use PhpLlm\LlmChain\Response\ResponseInterface;
 
-final readonly class Output
+final class Output
 {
     /**
      * @param array<string, mixed> $options
      */
     public function __construct(
-        public LanguageModel $llm,
+        public readonly LanguageModel $llm,
         public ResponseInterface $response,
-        public MessageBag $messages,
-        public array $options,
+        public readonly MessageBag $messages,
+        public readonly array $options,
     ) {
     }
 }

--- a/src/Chain/OutputProcessor.php
+++ b/src/Chain/OutputProcessor.php
@@ -6,5 +6,5 @@ namespace PhpLlm\LlmChain\Chain;
 
 interface OutputProcessor
 {
-    public function processOutput(Output $output): mixed;
+    public function processOutput(Output $output): void;
 }

--- a/src/StructuredOutput/ChainProcessor.php
+++ b/src/StructuredOutput/ChainProcessor.php
@@ -47,15 +47,25 @@ final class ChainProcessor implements InputProcessor, OutputProcessor
         $input->setOptions($options);
     }
 
-    public function processOutput(Output $output): ?StructuredResponse
+    public function processOutput(Output $output): void
     {
         $options = $output->options;
 
-        if (!isset($options['output_structure'])) {
-            return null;
+        if ($output->response instanceof StructuredResponse) {
+            return;
         }
 
-        return new StructuredResponse(
+        if (!isset($options['response_format'])) {
+            return;
+        }
+
+        if (!isset($this->outputStructure)) {
+            $output->response = new StructuredResponse(json_decode($output->response->getContent(), true));
+
+            return;
+        }
+
+        $output->response = new StructuredResponse(
             $this->serializer->deserialize($output->response->getContent(), $this->outputStructure, 'json')
         );
     }

--- a/src/ToolBox/ChainProcessor.php
+++ b/src/ToolBox/ChainProcessor.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\ToolBox;
 
+use PhpLlm\LlmChain\Chain\ChainAwareProcessor;
+use PhpLlm\LlmChain\Chain\ChainAwareTrait;
 use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\InputProcessor;
 use PhpLlm\LlmChain\Chain\Output;
 use PhpLlm\LlmChain\Chain\OutputProcessor;
 use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Message\Message;
-use PhpLlm\LlmChain\Response\ResponseInterface;
 use PhpLlm\LlmChain\Response\ToolCallResponse;
 
-final readonly class ChainProcessor implements InputProcessor, OutputProcessor
+final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwareProcessor
 {
+    use ChainAwareTrait;
+
     public function __construct(
         private ToolBoxInterface $toolBox,
     ) {
@@ -31,13 +34,12 @@ final readonly class ChainProcessor implements InputProcessor, OutputProcessor
         $input->setOptions($options);
     }
 
-    public function processOutput(Output $output): ResponseInterface
+    public function processOutput(Output $output): void
     {
-        $response = $output->response;
         $messages = clone $output->messages;
 
-        while ($response instanceof ToolCallResponse) {
-            $toolCalls = $response->getContent();
+        while ($output->response instanceof ToolCallResponse) {
+            $toolCalls = $output->response->getContent();
             $messages[] = Message::ofAssistant(toolCalls: $toolCalls);
 
             foreach ($toolCalls as $toolCall) {
@@ -45,9 +47,7 @@ final readonly class ChainProcessor implements InputProcessor, OutputProcessor
                 $messages[] = Message::ofToolCall($toolCall, $result);
             }
 
-            $response = $output->llm->call($messages, $output->options);
+            $output->response = $this->chain->call($messages, $output->options);
         }
-
-        return $response;
     }
 }

--- a/tests/StructuredOutput/ChainProcessorTest.php
+++ b/tests/StructuredOutput/ChainProcessorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhpLlm\LlmChain\Tests\ToolBox;
+namespace PhpLlm\LlmChain\Tests\StructuredOutput;
 
 use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\Output;
@@ -10,6 +10,7 @@ use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\LanguageModel;
 use PhpLlm\LlmChain\Message\MessageBag;
 use PhpLlm\LlmChain\Response\Choice;
+use PhpLlm\LlmChain\Response\StructuredResponse;
 use PhpLlm\LlmChain\Response\TextResponse;
 use PhpLlm\LlmChain\StructuredOutput\ChainProcessor;
 use PhpLlm\LlmChain\Tests\Double\ConfigurableResponseFormatFactory;
@@ -96,12 +97,13 @@ final class ChainProcessorTest extends TestCase
 
         $response = new TextResponse('{"some": "data"}');
 
-        $output = new Output($llm, $response, new MessageBag(), $options);
+        $output = new Output($llm, $response, new MessageBag(), $input->getOptions());
 
-        $result = $chainProcessor->processOutput($output)->getContent();
+        $chainProcessor->processOutput($output);
 
-        self::assertInstanceOf(SomeStructure::class, $result);
-        self::assertSame('data', $result->some);
+        self::assertInstanceOf(StructuredResponse::class, $output->response);
+        self::assertInstanceOf(SomeStructure::class, $output->response->getContent());
+        self::assertSame('data', $output->response->getContent()->some);
     }
 
     #[Test]
@@ -116,8 +118,8 @@ final class ChainProcessorTest extends TestCase
 
         $output = new Output($llm, $response, new MessageBag(), []);
 
-        $result = $chainProcessor->processOutput($output);
+        $chainProcessor->processOutput($output);
 
-        self::assertNull($result);
+        self::assertSame($response, $output->response);
     }
 }


### PR DESCRIPTION
Changes:
* Processors can be `ChainAware` now and with that leverage other processors recursively.
* `SturcturedOutput\ChainProcessor` now also supports plain `response_format` and decodes it to an assoc array, see example and screenshot below
* Multiple `OutputProcessor` can interfere now on the same response => no weird return, but via `Output` instance

![image](https://github.com/user-attachments/assets/963c4d71-b89c-4718-9566-93931050fcdd)