### PR TITLE
Conflict with PHPDocumentor higher then 5.5 because of doc parser bugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "conflict": {
         "mongodb/mongodb": "<1.20",
-		"phpdocumentor/reflection-docblock": ">=5.6"
+        "phpdocumentor/reflection-docblock": ">=5.6"
     },
     "suggest": {
         "codewithkyrian/chromadb-php": "For using the ChromaDB as retrieval vector store.",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "symfony/var-dumper": "^6.4 || ^7.1"
     },
     "conflict": {
-        "mongodb/mongodb": "<1.20"
+        "mongodb/mongodb": "<1.20",
+		"phpdocumentor/reflection-docblock": ">=5.6"
     },
     "suggest": {
         "codewithkyrian/chromadb-php": "For using the ChromaDB as retrieval vector store.",


### PR DESCRIPTION
There seem to be an error in the phpdocumentor of version 5.6 upwards which utilizes PHPStan phpdoc-parser in the fresh released version 2 and there is a compability problem. With 5.5 which does not allow the phpdoc-parser in v2 it is working as expected again. 

May need some time to do all the internal fixes before update.

See: 

```
There was 1 failure:

1) PhpLlm\LlmChain\Tests\StructuredOutput\ChainProcessorTest::processInputThrowsExceptionWhenLlmDoesNotSupportStructuredOutput
Failed asserting that exception of type "ArgumentCountError" matches expected exception "PhpLlm\LlmChain\Exception\MissingModelSupport". Message was: "Too few arguments to function PHPStan\PhpDocParser\Lexer\Lexer::__construct(), 0 passed in /home/runner/work/llm-chain/llm-chain/vendor/symfony/type-info/TypeResolver/StringTypeResolver.php on line 66 and exactly 1 expected" at
/home/runner/work/llm-chain/llm-chain/vendor/phpstan/phpdoc-parser/src/Lexer/Lexer.php:102
/home/runner/work/llm-chain/llm-chain/vendor/symfony/type-info/TypeResolver/StringTypeResolver.php:66
/home/runner/work/llm-chain/llm-chain/vendor/symfony/type-info/TypeResolver/TypeResolver.php:71
/home/runner/work/llm-chain/llm-chain/vendor/symfony/type-info/TypeResolver/TypeResolver.php:66
/home/runner/work/llm-chain/llm-chain/vendor/symfony/property-info/Extractor/ReflectionExtractor.php:102
/home/runner/work/llm-chain/llm-chain/vendor/symfony/property-access/PropertyAccessor.php:91
/home/runner/work/llm-chain/llm-chain/vendor/symfony/property-access/PropertyAccessorBuilder.php:289
/home/runner/work/llm-chain/llm-chain/vendor/symfony/property-access/PropertyAccess.php:26
/home/runner/work/llm-chain/llm-chain/vendor/symfony/serializer/Normalizer/ObjectNormalizer.php:53
/home/runner/work/llm-chain/llm-chain/tests/StructuredOutput/ChainProcessorTest.php:73
```