### PR TITLE
Add interface to final readonly chain for testability

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -14,7 +14,7 @@ use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Message\MessageBag;
 use PhpLlm\LlmChain\Response\ResponseInterface;
 
-final readonly class Chain
+final readonly class Chain implements ChainInterface
 {
     /**
      * @var InputProcessor[]

--- a/src/ChainInterface.php
+++ b/src/ChainInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain;
+
+use PhpLlm\LlmChain\Message\MessageBag;
+use PhpLlm\LlmChain\Response\ResponseInterface;
+
+interface ChainInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function call(MessageBag $messages, array $options = []): ResponseInterface;
+}


### PR DESCRIPTION
For simple mocks it would be cool to have the interface if the class is needed to be final and readonly as it is not a DTO but a service 😉 

Tests are failing cause of https://github.com/php-llm/llm-chain/pull/143