### PR TITLE
Extend parameter description pattern to stop for single line comment

### DIFF
--- a/src/ToolBox/ParameterAnalyzer.php
+++ b/src/ToolBox/ParameterAnalyzer.php
@@ -95,7 +95,7 @@ final class ParameterAnalyzer
             return '';
         }
 
-        $pattern = '/@param\s+\S+\s+\$'.preg_quote($paramName, '/').'\s+(.*)/';
+        $pattern = '/@param\s+\S+\s+\$'.preg_quote($paramName, '/').'\s+((.*)(?=\*)|.*)/';
         if (preg_match($pattern, $docComment, $matches)) {
             return trim($matches[1]);
         }

--- a/tests/ToolBox/ParameterAnalyzerTest.php
+++ b/tests/ToolBox/ParameterAnalyzerTest.php
@@ -215,24 +215,31 @@ final class ParameterAnalyzerTest extends TestCase
         ];
 
         yield 'multi line doc block with description and other tags' => [
-            'docComment' => '/** @param string $myParam The description
-			 * @return void
-			 */',
+            'docComment' => <<<'TEXT'
+                /**
+                 * @param string $myParam The description
+                 * @return void
+                 */
+            TEXT,
             'expectedResult' => 'The description',
         ];
 
         yield 'multi line doc block with multiple parameters' => [
-            'docComment' => '/**
-			 * @param string $myParam The description
-			 * @param string $anotherParam The wrong description
-			 */',
+            'docComment' => <<<'TEXT'
+                /**
+                 * @param string $myParam The description
+                 * @param string $anotherParam The wrong description
+                 */
+            TEXT,
             'expectedResult' => 'The description',
         ];
 
         yield 'multi line doc block with parameter that is not searched for' => [
-            'docComment' => '/**
-			 * @param string $unknownParam The description
-			 */',
+            'docComment' => <<<'TEXT'
+                /**
+                 * @param string $unknownParam The description
+                 */
+            TEXT,
             'expectedResult' => '',
         ];
     }


### PR DESCRIPTION
When utilizing single line comments the description of the argument in the toolbox contains `*/` of the closing comment. I have changed the regex to also have this supported. Also added new tests for the `ParameterAnalyzer` to check the parsing works as expected for different type of doc blocs.