### PR TITLE
Parse OpenAI response embedding to contain all embeddings

### DIFF
--- a/src/Bridge/OpenAI/Embeddings/ResponseConverter.php
+++ b/src/Bridge/OpenAI/Embeddings/ResponseConverter.php
@@ -22,6 +22,11 @@ final class ResponseConverter implements PlatformResponseConverter
     {
         $data = $response->toArray();
 
-        return new VectorResponse(new Vector($data['data'][0]['embedding']));
+        return new VectorResponse(
+            ...\array_map(
+                static fn (array $item): Vector => new Vector($item['embedding']),
+                $data['data']
+            ),
+        );
     }
 }

--- a/tests/Bridge/OpenAI/Embeddings/ResponseConverterTest.php
+++ b/tests/Bridge/OpenAI/Embeddings/ResponseConverterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Bridge\OpenAI\Embeddings;
+
+use PhpLlm\LlmChain\Bridge\OpenAI\Embeddings\ResponseConverter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[CoversClass(ResponseConverter::class)]
+#[Small]
+class ResponseConverterTest extends TestCase
+{
+    #[Test]
+    public function itConvertsAResponseToAVectorResponse(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response
+            ->method('toArray')
+            ->willReturn(\json_decode($this->getEmbeddingStub(), true));
+
+        $vectorResponse = (new ResponseConverter())->convert($response);
+        $convertedContent = $vectorResponse->getContent();
+
+        self::assertIsArray($convertedContent);
+        self::assertCount(2, $convertedContent);
+
+        self::assertSame([0.3, 0.4, 0.4], $convertedContent[0]->getData());
+        self::assertSame([0.0, 0.0, 0.2], $convertedContent[1]->getData());
+    }
+
+    private function getEmbeddingStub(): string
+    {
+        return <<<'JSON'
+        {
+          "object": "list",
+          "data": [
+            {
+              "object": "embedding",
+              "index": 0,
+              "embedding": [0.3, 0.4, 0.4]
+            },
+            {
+              "object": "embedding",
+              "index": 1,
+              "embedding": [0.0, 0.0, 0.2]
+            }
+          ]
+        }
+        JSON;
+    }
+}


### PR DESCRIPTION
When i request the embeddings with mutliple texts the response only contaion the first entry of the response. I did not really understand why it should be this way as the `VectorResponse` already supports having multiple vectors and so have adapted the response converter for the OpenAi Bridge embeddings. 

```php
$texts = array_fill(0, 20, 'Foo Bar Baz');
$vectors = $platform->request(new Embeddings(), $texts)->getContent();
```

The response of such a request, utilizing the OpenAI embeddings is an array with a single text or an array of text. So it does not change the current result of the `VectorResponse` for the user of the request.

Hope this fits? 

