### PR TITLE
Feature/refactor chain processor

### DIFF
--- a/examples/chat-claude-anthropic.php
+++ b/examples/chat-claude-anthropic.php
@@ -23,6 +23,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/chat-gpt-azure.php
+++ b/examples/chat-gpt-azure.php
@@ -29,6 +29,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/chat-gpt-openai.php
+++ b/examples/chat-gpt-openai.php
@@ -25,7 +25,7 @@ $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$response = $chain->call($messages, [
+$response = $chain->process($messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
 

--- a/examples/chat-llama-ollama.php
+++ b/examples/chat-llama-ollama.php
@@ -23,6 +23,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/chat-llama-replicate.php
+++ b/examples/chat-llama-replicate.php
@@ -23,6 +23,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/chat-o1-openai.php
+++ b/examples/chat-o1-openai.php
@@ -32,6 +32,6 @@ structure you'll need, then return each file in full. Only supply your reasoning
 at the beginning and end, not throughout the code.
 PROMPT;
 
-$response = (new Chain($platform, $llm))->call(new MessageBag(Message::ofUser($prompt)));
+$response = (new Chain($platform, $llm))->process(new MessageBag(Message::ofUser($prompt)));
 
 echo $response->getContent().PHP_EOL;

--- a/examples/image-describer-binary.php
+++ b/examples/image-describer-binary.php
@@ -27,6 +27,6 @@ $messages = new MessageBag(
         new Image(dirname(__DIR__).'/tests/Fixture/image.png'),
     ),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/image-describer-url.php
+++ b/examples/image-describer-url.php
@@ -27,6 +27,6 @@ $messages = new MessageBag(
         new Image('https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Webysther_20160423_-_Elephpant.svg/350px-Webysther_20160423_-_Elephpant.svg.png'),
     ),
 );
-$response = $chain->call($messages);
+$response = $chain->process($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/store-mongodb-similarity-search.php
+++ b/examples/store-mongodb-similarity-search.php
@@ -63,13 +63,13 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolBox = new ToolBox(new ToolAnalyzer(), [$similaritySearch]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),
     Message::ofUser('Which movie fits the theme of the mafia?')
 );
-$response = $chain->call($messages);
+$response = $chain->process(messages: $messages, chainProcessor: $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/store-pinecone-similarity-search.php
+++ b/examples/store-pinecone-similarity-search.php
@@ -54,13 +54,13 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolBox = new ToolBox(new ToolAnalyzer(), [$similaritySearch]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),
     Message::ofUser('Which movie fits the theme of the mafia?')
 );
-$response = $chain->call($messages);
+$response = $chain->process(messages: $messages, chainProcessor: $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/stream-claude-anthropic.php
+++ b/examples/stream-claude-anthropic.php
@@ -23,7 +23,7 @@ $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$response = $chain->call($messages, [
+$response = $chain->process($messages, [
     'stream' => true, // enable streaming of response text
 ]);
 

--- a/examples/stream-gpt-openai.php
+++ b/examples/stream-gpt-openai.php
@@ -23,7 +23,7 @@ $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$response = $chain->call($messages, [
+$response = $chain->process($messages, [
     'stream' => true, // enable streaming of response text
 ]);
 

--- a/examples/structured-output-math.php
+++ b/examples/structured-output-math.php
@@ -26,11 +26,11 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 $serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
 
 $processor = new ChainProcessor(new ResponseFormatFactory(), $serializer);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$chain = new Chain($platform, $llm);
 $messages = new MessageBag(
     Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
     Message::ofUser('how can I solve 8x + 7 = -23'),
 );
-$response = $chain->call($messages, ['output_structure' => MathReasoning::class]);
+$response = $chain->process($messages, ['output_structure' => MathReasoning::class], $processor);
 
 dump($response->getContent());

--- a/examples/toolbox-clock.php
+++ b/examples/toolbox-clock.php
@@ -25,10 +25,10 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $clock = new Clock(new SymfonyClock());
 $toolBox = new ToolBox(new ToolAnalyzer(), [$clock]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
-$response = $chain->call($messages);
+$response = $chain->process($messages, [], $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/toolbox-serpapi.php
+++ b/examples/toolbox-serpapi.php
@@ -24,10 +24,10 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $serpApi = new SerpApi(HttpClient::create(), $_ENV['SERP_API_KEY']);
 $toolBox = new ToolBox(new ToolAnalyzer(), [$serpApi]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
-$response = $chain->call($messages);
+$response = $chain->process(messages: $messages, chainProcessor: $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/toolbox-weather.php
+++ b/examples/toolbox-weather.php
@@ -25,10 +25,10 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $wikipedia = new OpenMeteo(HttpClient::create());
 $toolBox = new ToolBox(new ToolAnalyzer(), [$wikipedia]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(Message::ofUser('How is the weather currently in Berlin?'));
-$response = $chain->call($messages);
+$response = $chain->process($messages, [], $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/toolbox-wikipedia.php
+++ b/examples/toolbox-wikipedia.php
@@ -25,10 +25,10 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $wikipedia = new Wikipedia(HttpClient::create());
 $toolBox = new ToolBox(new ToolAnalyzer(), [$wikipedia]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
-$response = $chain->call($messages);
+$response = $chain->process(messages: $messages, chainProcessor: $processor);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/toolbox-youtube.php
+++ b/examples/toolbox-youtube.php
@@ -25,13 +25,13 @@ $llm = new GPT(GPT::GPT_4O_MINI);
 
 $transcriber = new YouTubeTranscriber(HttpClient::create());
 $toolBox = new ToolBox(new ToolAnalyzer(), [$transcriber]);
-$processor = new ChainProcessor($toolBox);
-$chain = new Chain($platform, $llm, [$processor], [$processor]);
+$processor = (new ChainProcessor())->withToolBox($toolBox);
+$chain = new Chain($platform, $llm);
 
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
-$response = $chain->call($messages, [
+$response = $chain->process($messages, [
     'stream' => true, // enable streaming of response text
-]);
+], $processor);
 
 foreach ($response->getContent() as $word) {
     echo $word;

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -28,8 +28,9 @@ final readonly class Chain implements ChainInterface
      */
     public function process(MessageBag $messages, array $options = [], ?ChainAwareProcessor $chainProcessor = null): ResponseInterface
     {
-        $input = new Input($this->llm, $messages, $options);
+        $chainProcessor?->setChain($this);
 
+        $input = new Input($this->llm, $messages, $options);
         if ($chainProcessor) {
             array_map(fn (InputProcessor $processor) => $processor->processInput($input), $chainProcessor->getInputProcessors());
         }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -9,7 +9,6 @@ use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\InputProcessor;
 use PhpLlm\LlmChain\Chain\Output;
 use PhpLlm\LlmChain\Chain\OutputProcessor;
-use PhpLlm\LlmChain\Exception\InvalidArgumentException;
 use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Model\LanguageModel;
 use PhpLlm\LlmChain\Model\Message\MessageBag;
@@ -18,37 +17,22 @@ use PhpLlm\LlmChain\Model\Response\ResponseInterface;
 
 final readonly class Chain implements ChainInterface
 {
-    /**
-     * @var InputProcessor[]
-     */
-    private array $inputProcessor;
-
-    /**
-     * @var OutputProcessor[]
-     */
-    private array $outputProcessor;
-
-    /**
-     * @param InputProcessor[]  $inputProcessor
-     * @param OutputProcessor[] $outputProcessor
-     */
     public function __construct(
         private PlatformInterface $platform,
         private LanguageModel $llm,
-        iterable $inputProcessor = [],
-        iterable $outputProcessor = [],
     ) {
-        $this->inputProcessor = $this->initializeProcessors($inputProcessor, InputProcessor::class);
-        $this->outputProcessor = $this->initializeProcessors($outputProcessor, OutputProcessor::class);
     }
 
     /**
      * @param array<string, mixed> $options
      */
-    public function call(MessageBag $messages, array $options = []): ResponseInterface
+    public function process(MessageBag $messages, array $options = [], ?ChainAwareProcessor $chainProcessor = null): ResponseInterface
     {
         $input = new Input($this->llm, $messages, $options);
-        array_map(fn (InputProcessor $processor) => $processor->processInput($input), $this->inputProcessor);
+
+        if ($chainProcessor) {
+            array_map(fn (InputProcessor $processor) => $processor->processInput($input), $chainProcessor->getInputProcessors());
+        }
 
         if ($messages->containsImage() && !$this->llm->supportsImageInput()) {
             throw MissingModelSupport::forImageInput($this->llm::class);
@@ -61,28 +45,11 @@ final readonly class Chain implements ChainInterface
         }
 
         $output = new Output($this->llm, $response, $messages, $options);
-        array_map(fn (OutputProcessor $processor) => $processor->processOutput($output), $this->outputProcessor);
 
-        return $output->response;
-    }
-
-    /**
-     * @param InputProcessor[]|OutputProcessor[] $processors
-     *
-     * @return InputProcessor[]|OutputProcessor[]
-     */
-    private function initializeProcessors(iterable $processors, string $interface): array
-    {
-        foreach ($processors as $processor) {
-            if (!$processor instanceof $interface) {
-                throw new InvalidArgumentException(sprintf('Processor %s must implement %s interface.', $processor::class, $interface));
-            }
-
-            if ($processor instanceof ChainAwareProcessor) {
-                $processor->setChain($this);
-            }
+        if ($chainProcessor) {
+            array_map(fn (OutputProcessor $processor) => $processor->processOutput($output), $chainProcessor->getOutputProcessors());
         }
 
-        return $processors instanceof \Traversable ? iterator_to_array($processors) : $processors;
+        return $output->response;
     }
 }

--- a/src/Chain/ChainAwareProcessor.php
+++ b/src/Chain/ChainAwareProcessor.php
@@ -9,4 +9,28 @@ use PhpLlm\LlmChain\Chain;
 interface ChainAwareProcessor
 {
     public function setChain(Chain $chain): void;
+
+    public function addOutputProcessor(OutputProcessor $outputProcessor): self;
+
+    public function addInputProcessor(InputProcessor $outputProcessor): self;
+
+    /**
+     * @return array<InputProcessor>
+     */
+    public function getInputProcessors(): array;
+
+    /**
+     * @return array<OutputProcessor>
+     */
+    public function getOutputProcessors(): array;
+
+    /**
+     * @param array<InputProcessor> $inputProcessors
+     */
+    public function setInputProcessors(array $inputProcessors): self;
+
+    /**
+     * @param array<OutputProcessor> $outputProcessors
+     */
+    public function setOutputProcessors(array $outputProcessors): self;
 }

--- a/src/Chain/ChainAwareProcessor.php
+++ b/src/Chain/ChainAwareProcessor.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Chain;
 
-use PhpLlm\LlmChain\Chain;
+use PhpLlm\LlmChain\ChainInterface;
 
 interface ChainAwareProcessor
 {
-    public function setChain(Chain $chain): void;
+    public function setChain(ChainInterface $chain): void;
 
     public function addOutputProcessor(OutputProcessor $outputProcessor): self;
 

--- a/src/Chain/ChainAwareTrait.php
+++ b/src/Chain/ChainAwareTrait.php
@@ -5,13 +5,76 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Chain;
 
 use PhpLlm\LlmChain\Chain;
+use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
 
 trait ChainAwareTrait
 {
     private Chain $chain;
 
+    private ToolBoxInterface $toolBox;
+
+    /**
+     * @var InputProcessor[]
+     */
+    private array $inputProcessors;
+
+    /**
+     * @var OutputProcessor[]
+     */
+    private array $outputProcessors;
+
     public function setChain(Chain $chain): void
     {
         $this->chain = $chain;
+    }
+
+    public function getInputProcessors(): array
+    {
+        return $this->inputProcessors;
+    }
+
+    public function getOutputProcessors(): array
+    {
+        return $this->outputProcessors;
+    }
+
+    public function addOutputProcessor(OutputProcessor $outputProcessor): self
+    {
+        if (!in_array($outputProcessor, $this->outputProcessors)) {
+            $this->outputProcessors[] = $outputProcessor;
+        }
+
+        return $this;
+    }
+
+    public function addInputProcessor(InputProcessor $outputProcessor): self
+    {
+        if (!in_array($outputProcessor, $this->inputProcessors)) {
+            $this->inputProcessors[] = $outputProcessor;
+        }
+
+        return $this;
+    }
+
+    public function setOutputProcessors(array $outputProcessors): self
+    {
+        $this->outputProcessors = $outputProcessors;
+
+        return $this;
+    }
+
+    public function setInputProcessors(array $inputProcessors): self
+    {
+        $this->inputProcessors = $inputProcessors;
+
+        return $this;
+    }
+
+    public function withToolBox(ToolBoxInterface $toolBox): self
+    {
+        $chain = clone $this;
+        $chain->toolBox = $toolBox;
+
+        return $chain;
     }
 }

--- a/src/Chain/ChainAwareTrait.php
+++ b/src/Chain/ChainAwareTrait.php
@@ -4,26 +4,27 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Chain;
 
-use PhpLlm\LlmChain\Chain;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
+use PhpLlm\LlmChain\ChainInterface;
+use PhpLlm\LlmChain\Exception\InvalidArgumentException;
 
 trait ChainAwareTrait
 {
-    private Chain $chain;
+    private ChainInterface $chain;
 
     private ToolBoxInterface $toolBox;
 
     /**
      * @var InputProcessor[]
      */
-    private array $inputProcessors;
+    private array $inputProcessors = [];
 
     /**
      * @var OutputProcessor[]
      */
-    private array $outputProcessors;
+    private array $outputProcessors = [];
 
-    public function setChain(Chain $chain): void
+    public function setChain(ChainInterface $chain): void
     {
         $this->chain = $chain;
     }
@@ -56,16 +57,28 @@ trait ChainAwareTrait
         return $this;
     }
 
-    public function setOutputProcessors(array $outputProcessors): self
+    public function setOutputProcessors(iterable $outputProcessors): self
     {
-        $this->outputProcessors = $outputProcessors;
+        foreach ($outputProcessors as $processor) {
+            if (!$processor instanceof OutputProcessor) {
+                throw new InvalidArgumentException(sprintf('Processor %s must implement %s interface.', $processor::class, OutputProcessor::class));
+            }
+
+            $this->addOutputProcessor($processor);
+        }
 
         return $this;
     }
 
-    public function setInputProcessors(array $inputProcessors): self
+    public function setInputProcessors(iterable $inputProcessors): self
     {
-        $this->inputProcessors = $inputProcessors;
+        foreach ($inputProcessors as $processor) {
+            if (!$processor instanceof InputProcessor) {
+                throw new InvalidArgumentException(sprintf('Processor %s must implement %s interface.', $processor::class, InputProcessor::class));
+            }
+
+            $this->addInputProcessor($processor);
+        }
 
         return $this;
     }

--- a/src/Chain/StructuredOutput/ChainProcessor.php
+++ b/src/Chain/StructuredOutput/ChainProcessor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Chain\StructuredOutput;
 
+use PhpLlm\LlmChain\Chain\ChainAwareProcessor;
+use PhpLlm\LlmChain\Chain\ChainAwareTrait;
 use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\InputProcessor;
 use PhpLlm\LlmChain\Chain\Output;
@@ -13,8 +15,10 @@ use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Model\Response\StructuredResponse;
 use Symfony\Component\Serializer\SerializerInterface;
 
-final class ChainProcessor implements InputProcessor, OutputProcessor
+final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwareProcessor
 {
+    use ChainAwareTrait;
+
     private string $outputStructure;
 
     public function __construct(

--- a/src/Chain/ToolBox/ChainProcessor.php
+++ b/src/Chain/ToolBox/ChainProcessor.php
@@ -7,21 +7,14 @@ namespace PhpLlm\LlmChain\Chain\ToolBox;
 use PhpLlm\LlmChain\Chain\ChainAwareProcessor;
 use PhpLlm\LlmChain\Chain\ChainAwareTrait;
 use PhpLlm\LlmChain\Chain\Input;
-use PhpLlm\LlmChain\Chain\InputProcessor;
 use PhpLlm\LlmChain\Chain\Output;
-use PhpLlm\LlmChain\Chain\OutputProcessor;
 use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Model\Message\Message;
 use PhpLlm\LlmChain\Model\Response\ToolCallResponse;
 
-final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwareProcessor
+final class ChainProcessor implements ChainAwareProcessor
 {
     use ChainAwareTrait;
-
-    public function __construct(
-        private ToolBoxInterface $toolBox,
-    ) {
-    }
 
     public function processInput(Input $input): void
     {
@@ -52,7 +45,7 @@ final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwar
                 $messages[] = Message::ofToolCall($toolCall, $result);
             }
 
-            $output->response = $this->chain->call($messages, $output->options);
+            $output->response = $this->chain->process($messages, $output->options, $this);
         }
     }
 }

--- a/src/Chain/ToolBox/ChainProcessor.php
+++ b/src/Chain/ToolBox/ChainProcessor.php
@@ -7,12 +7,14 @@ namespace PhpLlm\LlmChain\Chain\ToolBox;
 use PhpLlm\LlmChain\Chain\ChainAwareProcessor;
 use PhpLlm\LlmChain\Chain\ChainAwareTrait;
 use PhpLlm\LlmChain\Chain\Input;
+use PhpLlm\LlmChain\Chain\InputProcessor;
 use PhpLlm\LlmChain\Chain\Output;
+use PhpLlm\LlmChain\Chain\OutputProcessor;
 use PhpLlm\LlmChain\Exception\MissingModelSupport;
 use PhpLlm\LlmChain\Model\Message\Message;
 use PhpLlm\LlmChain\Model\Response\ToolCallResponse;
 
-final class ChainProcessor implements ChainAwareProcessor
+final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwareProcessor
 {
     use ChainAwareTrait;
 

--- a/src/ChainInterface.php
+++ b/src/ChainInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain;
 
+use PhpLlm\LlmChain\Chain\ChainAwareProcessor;
 use PhpLlm\LlmChain\Model\Message\MessageBag;
 use PhpLlm\LlmChain\Model\Response\ResponseInterface;
 
@@ -12,5 +13,5 @@ interface ChainInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function call(MessageBag $messages, array $options = []): ResponseInterface;
+    public function process(MessageBag $messages, array $options = [], ?ChainAwareProcessor $chainProcessor = null): ResponseInterface;
 }

--- a/tests/Chain/ToolBox/ChainProcessorTest.php
+++ b/tests/Chain/ToolBox/ChainProcessorTest.php
@@ -30,7 +30,7 @@ class ChainProcessorTest extends TestCase
         $llm = $this->createMock(LanguageModel::class);
         $llm->method('supportsToolCalling')->willReturn(true);
 
-        $chainProcessor = new ChainProcessor($toolBox);
+        $chainProcessor = (new ChainProcessor())->withToolBox($toolBox);
         $input = new Input($llm, new MessageBag(), []);
 
         $chainProcessor->processInput($input);
@@ -47,7 +47,7 @@ class ChainProcessorTest extends TestCase
         $llm = $this->createMock(LanguageModel::class);
         $llm->method('supportsToolCalling')->willReturn(true);
 
-        $chainProcessor = new ChainProcessor($toolBox);
+        $chainProcessor = (new ChainProcessor())->withToolBox($toolBox);
         $input = new Input($llm, new MessageBag(), []);
 
         $chainProcessor->processInput($input);
@@ -63,7 +63,7 @@ class ChainProcessorTest extends TestCase
         $llm = $this->createMock(LanguageModel::class);
         $llm->method('supportsToolCalling')->willReturn(false);
 
-        $chainProcessor = new ChainProcessor($this->createStub(ToolBoxInterface::class));
+        $chainProcessor = new ChainProcessor();
         $input = new Input($llm, new MessageBag(), []);
 
         $chainProcessor->processInput($input);

--- a/tests/Fixture/Tool/ToolWithoutAttribute.php
+++ b/tests/Fixture/Tool/ToolWithoutAttribute.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Tests\Fixture\Tool;
 
-final class ToolWrong
+final class ToolWithoutAttribute
 {
     /**
      * @param string $text   The text given to the tool


### PR DESCRIPTION
I did some refactor and renaming method 
I see that when we want to process messages with a chain we invoke the method with two arrays contains the same variable (`$chain = new Chain($platform, $llm, [$processor], [$processor]);`)

I changed the signature of  this method 

`public function call(MessageBag $messages, array $options = []): ResponseInterface`

To be like 

`public function process(MessageBag $messages, array $options = [], ?ChainAwareProcessor $chainProcessor = null): ResponseInterface`

The $chainProcessor will have the outputProcessors and inputProcessors and will be used in need .

