### PR TITLE
[BC BREAK] `MessageBag` does not depend on `\ArrayObject` anymore

### DIFF
--- a/src/Bridge/Meta/LlamaPromptConverter.php
+++ b/src/Bridge/Meta/LlamaPromptConverter.php
@@ -19,7 +19,7 @@ final class LlamaPromptConverter
         $messages = [];
 
         /** @var UserMessage|SystemMessage|AssistantMessage $message */
-        foreach ($messageBag->getIterator() as $message) {
+        foreach ($messageBag->getMessages() as $message) {
             $messages[] = self::convertMessage($message);
         }
 

--- a/src/Chain/ToolBox/ChainProcessor.php
+++ b/src/Chain/ToolBox/ChainProcessor.php
@@ -45,11 +45,11 @@ final class ChainProcessor implements InputProcessor, OutputProcessor, ChainAwar
 
         while ($output->response instanceof ToolCallResponse) {
             $toolCalls = $output->response->getContent();
-            $messages[] = Message::ofAssistant(toolCalls: $toolCalls);
+            $messages->add(Message::ofAssistant(toolCalls: $toolCalls));
 
             foreach ($toolCalls as $toolCall) {
                 $result = $this->toolBox->execute($toolCall);
-                $messages[] = Message::ofToolCall($toolCall, $result);
+                $messages->add(Message::ofToolCall($toolCall, $result));
             }
 
             $output->response = $this->chain->call($messages, $output->options);

--- a/tests/Bridge/Meta/LlamaPromptConverterTest.php
+++ b/tests/Bridge/Meta/LlamaPromptConverterTest.php
@@ -26,7 +26,7 @@ final class LlamaPromptConverterTest extends TestCase
     {
         $messageBag = new MessageBag();
         foreach (self::provideMessages() as $message) {
-            $messageBag->append($message[1]);
+            $messageBag->add($message[1]);
         }
 
         self::assertSame(<<<EXPECTED

--- a/tests/Model/Message/MessageBagTest.php
+++ b/tests/Model/Message/MessageBagTest.php
@@ -70,7 +70,7 @@ final class MessageBagTest extends TestCase
         self::assertCount(3, $messageBag);
         self::assertCount(4, $newMessageBag);
 
-        $newMessageFromBag = $newMessageBag[3];
+        $newMessageFromBag = $newMessageBag->getMessages()[3];
 
         self::assertInstanceOf(AssistantMessage::class, $newMessageFromBag);
         self::assertSame('It is time to wake up.', $newMessageFromBag->content);
@@ -91,7 +91,7 @@ final class MessageBagTest extends TestCase
 
         self::assertCount(4, $messageBag);
 
-        $messageFromBag = $messageBag[3];
+        $messageFromBag = $messageBag->getMessages()[3];
 
         self::assertInstanceOf(AssistantMessage::class, $messageFromBag);
         self::assertSame('It is time to wake up.', $messageFromBag->content);
@@ -111,7 +111,7 @@ final class MessageBagTest extends TestCase
         self::assertCount(3, $messageBag);
         self::assertCount(2, $newMessageBag);
 
-        $messageFromNewBag = $newMessageBag[0];
+        $messageFromNewBag = $newMessageBag->getMessages()[0];
 
         self::assertInstanceOf(AssistantMessage::class, $messageFromNewBag);
         self::assertSame('It is time to sleep.', $messageFromNewBag->content);
@@ -131,14 +131,14 @@ final class MessageBagTest extends TestCase
         self::assertCount(2, $messageBag);
         self::assertCount(3, $newMessageBag);
 
-        $newMessageBagMessage = $newMessageBag[0];
+        $newMessageBagMessage = $newMessageBag->getMessages()[0];
 
         self::assertInstanceOf(SystemMessage::class, $newMessageBagMessage);
         self::assertSame('My amazing system prompt.', $newMessageBagMessage->content);
     }
 
     #[Test]
-    public function containsImageWithoutImage(): void
+    public function containsImageReturnsFalseWithoutImage(): void
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),
@@ -149,7 +149,7 @@ final class MessageBagTest extends TestCase
     }
 
     #[Test]
-    public function containsImageWithImage(): void
+    public function containsImageReturnsTrueWithImage(): void
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),


### PR DESCRIPTION
Follows
* https://github.com/php-llm/llm-chain/pull/166/files#r1898145794
