### PR TITLE
Unfinalize `MessageBag`

### DIFF
--- a/src/Model/Message/MessageBag.php
+++ b/src/Model/Message/MessageBag.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Message;
 
-final class MessageBag implements MessageBagInterface
+/**
+ * @final
+ */
+class MessageBag implements MessageBagInterface
 {
     /**
      * @var list<MessageInterface>


### PR DESCRIPTION
This is just an idea.
The `@final` that we don't cover BC and you extend on your own risk, that's how Symfony is doing such things.

I could then end up with just this to achieve my goals:
```php
<?php

declare(strict_types=1);

namespace App\Bridge\PhpLlm;

use PhpLlm\LlmChain\Model\Message\MessageBag;
use PhpLlm\LlmChain\Model\Message\MessageInterface;

final class EnhancedMessageBag extends MessageBag
{
    public function __construct(MessageInterface ...$messages)
    {
        parent::__construct(...array_map([$this, 'wrap'], array_values($messages)));
    }

    public function add(MessageInterface $message): void
    {
        parent::add($this->wrap($message));
    }

    private function wrap(MessageInterface $message): MessageInterface
    {
        if ($message instanceof EnhancedMessage) {
            return $message;
        }

        return new EnhancedMessage($message);
    }
}
```