### PR TITLE
fix: Dall-E image generation examples

### DIFF
--- a/examples/image-generator-dall-e-2.php
+++ b/examples/image-generator-dall-e-2.php
@@ -15,10 +15,9 @@ if (empty($_ENV['OPENAI_API_KEY'])) {
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
 
 $response = $platform->request(
-    model: new DallE(),
+    model: new DallE(), // Utilize Dall-E 2 version in default
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
-        'version' => DallE::DALL_E_2, // Utilize Dall-E 2 version
         'response_format' => 'url', // Generate response as URL
         'n' => 2, // Generate multiple images for example
     ],

--- a/examples/image-generator-dall-e-3.php
+++ b/examples/image-generator-dall-e-3.php
@@ -17,10 +17,10 @@ if (empty($_ENV['OPENAI_API_KEY'])) {
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
 
 $response = $platform->request(
-    model: new DallE(),
+    model: new DallE(version: DallE::DALL_E_3),
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
-        'version' => DallE::DALL_E_3, // Utilize Dall-E 3 version
+        'response_format' => 'url', // Generate response as URL
     ],
 );
 


### PR DESCRIPTION
Within my PR #178 i had last changed the options within the examples but did not test them again. The plain option for the API is `model` and not `version` like in the `DallE` model class. So here the examples are fixed.