### PR TITLE
refactor: rename tool param attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ LLM Chain generates a JSON Schema representation for all tools in the `ToolBox` 
 method arguments and param comments in the doc block. Additionally, JSON Schema support validation rules, which are
 partially support by LLMs like GPT.
 
-To leverage this, configure the `#[ToolParameter]` attribute on the method arguments of your tool:
+To leverage this, configure the `#[With]` attribute on the method arguments of your tool:
 ```php
-use PhpLlm\LlmChain\ToolBox\Attribute\AsTool;
-use PhpLlm\LlmChain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
 
 #[AsTool('my_tool', 'Example tool with parameters requirements.')]
 final class MyTool
@@ -212,9 +212,9 @@ final class MyTool
      * @param int    $number The number of an object
      */
     public function __invoke(
-        #[ToolParameter(pattern: '/([a-z0-1]){5}/')]
+        #[With(pattern: '/([a-z0-1]){5}/')]
         string $name,
-        #[ToolParameter(minimum: 0, maximum: 10)]   
+        #[With(minimum: 0, maximum: 10)]   
         int $number,
     ): string {
         // ...
@@ -222,7 +222,7 @@ final class MyTool
 }
 ```
 
-See attribute class [ToolParameter](src/Chain/ToolBox/Attribute/ToolParameter.php) for all available options.
+See attribute class [With](src/Chain/ToolBox/Attribute/With.php) for all available options.
 
 > [!NOTE]
 > Please be aware, that this is only converted in a JSON Schema for the LLM to respect, but not validated by LLM Chain.

--- a/src/Chain/ToolBox/Attribute/With.php
+++ b/src/Chain/ToolBox/Attribute/With.php
@@ -7,7 +7,7 @@ namespace PhpLlm\LlmChain\Chain\ToolBox\Attribute;
 use Webmozart\Assert\Assert;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-final readonly class ToolParameter
+final readonly class With
 {
     /**
      * @param list<int|string>|null    $enum

--- a/src/Chain/ToolBox/ParameterAnalyzer.php
+++ b/src/Chain/ToolBox/ParameterAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Chain\ToolBox;
 
-use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\With;
 use PhpLlm\LlmChain\Chain\ToolBox\Exception\ToolConfigurationException;
 
 /**
@@ -81,7 +81,7 @@ final class ParameterAnalyzer
             ];
 
             // Check for ToolParameter attributes
-            $attributes = $parameter->getAttributes(ToolParameter::class);
+            $attributes = $parameter->getAttributes(With::class);
             if (count($attributes) > 0) {
                 $attributeState = array_filter((array) $attributes[0]->newInstance(), fn ($value) => null !== $value);
                 $property = array_merge($property, $attributeState);

--- a/src/Chain/ToolBox/Tool/OpenMeteo.php
+++ b/src/Chain/ToolBox/Tool/OpenMeteo.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Chain\ToolBox\Tool;
 
 use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
-use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\With;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsTool(name: 'weather_current', description: 'get current weather for a location', method: 'current')]
@@ -94,7 +94,7 @@ final readonly class OpenMeteo
     public function forecast(
         float $latitude,
         float $longitude,
-        #[ToolParameter(minimum: 1, maximum: 16)]
+        #[With(minimum: 1, maximum: 16)]
         int $days = 7,
     ): array {
         $response = $this->httpClient->request('GET', 'https://api.open-meteo.com/v1/forecast', [

--- a/tests/Chain/ToolBox/Attribute/ToolParameterTest.php
+++ b/tests/Chain/ToolBox/Attribute/ToolParameterTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Tests\Chain\ToolBox\Attribute;
 
-use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\With;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\InvalidArgumentException;
 
-#[CoversClass(ToolParameter::class)]
+#[CoversClass(With::class)]
 final class ToolParameterTest extends TestCase
 {
     #[Test]
     public function validEnum(): void
     {
         $enum = ['value1', 'value2'];
-        $toolParameter = new ToolParameter(enum: $enum);
+        $toolParameter = new With(enum: $enum);
         self::assertSame($enum, $toolParameter->enum);
     }
 
@@ -26,14 +26,14 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $enum = ['value1', 2];
-        new ToolParameter(enum: $enum);
+        new With(enum: $enum);
     }
 
     #[Test]
     public function validConstString(): void
     {
         $const = 'constant value';
-        $toolParameter = new ToolParameter(const: $const);
+        $toolParameter = new With(const: $const);
         self::assertSame($const, $toolParameter->const);
     }
 
@@ -42,14 +42,14 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $const = '   ';
-        new ToolParameter(const: $const);
+        new With(const: $const);
     }
 
     #[Test]
     public function validPattern(): void
     {
         $pattern = '/^[a-z]+$/';
-        $toolParameter = new ToolParameter(pattern: $pattern);
+        $toolParameter = new With(pattern: $pattern);
         self::assertSame($pattern, $toolParameter->pattern);
     }
 
@@ -58,14 +58,14 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $pattern = '   ';
-        new ToolParameter(pattern: $pattern);
+        new With(pattern: $pattern);
     }
 
     #[Test]
     public function validMinLength(): void
     {
         $minLength = 5;
-        $toolParameter = new ToolParameter(minLength: $minLength);
+        $toolParameter = new With(minLength: $minLength);
         self::assertSame($minLength, $toolParameter->minLength);
     }
 
@@ -73,7 +73,7 @@ final class ToolParameterTest extends TestCase
     public function invalidMinLengthNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minLength: -1);
+        new With(minLength: -1);
     }
 
     #[Test]
@@ -81,7 +81,7 @@ final class ToolParameterTest extends TestCase
     {
         $minLength = 5;
         $maxLength = 10;
-        $toolParameter = new ToolParameter(minLength: $minLength, maxLength: $maxLength);
+        $toolParameter = new With(minLength: $minLength, maxLength: $maxLength);
         self::assertSame($minLength, $toolParameter->minLength);
         self::assertSame($maxLength, $toolParameter->maxLength);
     }
@@ -90,14 +90,14 @@ final class ToolParameterTest extends TestCase
     public function invalidMaxLengthLessThanMinLength(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minLength: 10, maxLength: 5);
+        new With(minLength: 10, maxLength: 5);
     }
 
     #[Test]
     public function validMinimum(): void
     {
         $minimum = 0;
-        $toolParameter = new ToolParameter(minimum: $minimum);
+        $toolParameter = new With(minimum: $minimum);
         self::assertSame($minimum, $toolParameter->minimum);
     }
 
@@ -105,14 +105,14 @@ final class ToolParameterTest extends TestCase
     public function invalidMinimumNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minimum: -1);
+        new With(minimum: -1);
     }
 
     #[Test]
     public function validMultipleOf(): void
     {
         $multipleOf = 5;
-        $toolParameter = new ToolParameter(multipleOf: $multipleOf);
+        $toolParameter = new With(multipleOf: $multipleOf);
         self::assertSame($multipleOf, $toolParameter->multipleOf);
     }
 
@@ -120,7 +120,7 @@ final class ToolParameterTest extends TestCase
     public function invalidMultipleOfNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(multipleOf: -5);
+        new With(multipleOf: -5);
     }
 
     #[Test]
@@ -128,7 +128,7 @@ final class ToolParameterTest extends TestCase
     {
         $exclusiveMinimum = 1;
         $exclusiveMaximum = 10;
-        $toolParameter = new ToolParameter(exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum);
+        $toolParameter = new With(exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum);
         self::assertSame($exclusiveMinimum, $toolParameter->exclusiveMinimum);
         self::assertSame($exclusiveMaximum, $toolParameter->exclusiveMaximum);
     }
@@ -137,7 +137,7 @@ final class ToolParameterTest extends TestCase
     public function invalidExclusiveMaximumLessThanExclusiveMinimum(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(exclusiveMinimum: 10, exclusiveMaximum: 5);
+        new With(exclusiveMinimum: 10, exclusiveMaximum: 5);
     }
 
     #[Test]
@@ -145,7 +145,7 @@ final class ToolParameterTest extends TestCase
     {
         $minItems = 1;
         $maxItems = 5;
-        $toolParameter = new ToolParameter(minItems: $minItems, maxItems: $maxItems);
+        $toolParameter = new With(minItems: $minItems, maxItems: $maxItems);
         self::assertSame($minItems, $toolParameter->minItems);
         self::assertSame($maxItems, $toolParameter->maxItems);
     }
@@ -154,13 +154,13 @@ final class ToolParameterTest extends TestCase
     public function invalidMaxItemsLessThanMinItems(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minItems: 5, maxItems: 1);
+        new With(minItems: 5, maxItems: 1);
     }
 
     #[Test]
     public function validUniqueItemsTrue(): void
     {
-        $toolParameter = new ToolParameter(uniqueItems: true);
+        $toolParameter = new With(uniqueItems: true);
         self::assertTrue($toolParameter->uniqueItems);
     }
 
@@ -168,7 +168,7 @@ final class ToolParameterTest extends TestCase
     public function invalidUniqueItemsFalse(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(uniqueItems: false);
+        new With(uniqueItems: false);
     }
 
     #[Test]
@@ -176,7 +176,7 @@ final class ToolParameterTest extends TestCase
     {
         $minContains = 1;
         $maxContains = 3;
-        $toolParameter = new ToolParameter(minContains: $minContains, maxContains: $maxContains);
+        $toolParameter = new With(minContains: $minContains, maxContains: $maxContains);
         self::assertSame($minContains, $toolParameter->minContains);
         self::assertSame($maxContains, $toolParameter->maxContains);
     }
@@ -185,13 +185,13 @@ final class ToolParameterTest extends TestCase
     public function invalidMaxContainsLessThanMinContains(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minContains: 3, maxContains: 1);
+        new With(minContains: 3, maxContains: 1);
     }
 
     #[Test]
     public function validRequired(): void
     {
-        $toolParameter = new ToolParameter(required: true);
+        $toolParameter = new With(required: true);
         self::assertTrue($toolParameter->required);
     }
 
@@ -200,7 +200,7 @@ final class ToolParameterTest extends TestCase
     {
         $minProperties = 1;
         $maxProperties = 5;
-        $toolParameter = new ToolParameter(minProperties: $minProperties, maxProperties: $maxProperties);
+        $toolParameter = new With(minProperties: $minProperties, maxProperties: $maxProperties);
         self::assertSame($minProperties, $toolParameter->minProperties);
         self::assertSame($maxProperties, $toolParameter->maxProperties);
     }
@@ -209,20 +209,20 @@ final class ToolParameterTest extends TestCase
     public function invalidMaxPropertiesLessThanMinProperties(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minProperties: 5, maxProperties: 1);
+        new With(minProperties: 5, maxProperties: 1);
     }
 
     #[Test]
     public function validDependentRequired(): void
     {
-        $toolParameter = new ToolParameter(dependentRequired: true);
+        $toolParameter = new With(dependentRequired: true);
         self::assertTrue($toolParameter->dependentRequired);
     }
 
     #[Test]
     public function validCombination(): void
     {
-        $toolParameter = new ToolParameter(
+        $toolParameter = new With(
             enum: ['value1', 'value2'],
             const: 'constant',
             pattern: '/^[a-z]+$/',
@@ -244,13 +244,13 @@ final class ToolParameterTest extends TestCase
             dependentRequired: true
         );
 
-        self::assertInstanceOf(ToolParameter::class, $toolParameter);
+        self::assertInstanceOf(With::class, $toolParameter);
     }
 
     #[Test]
     public function invalidCombination(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new ToolParameter(minLength: -1, maxLength: -2);
+        new With(minLength: -1, maxLength: -2);
     }
 }

--- a/tests/Chain/ToolBox/ParameterAnalyzerTest.php
+++ b/tests/Chain/ToolBox/ParameterAnalyzerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Tests\Chain\ToolBox;
 
 use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
-use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\With;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\ParameterAnalyzer;
 use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolNoParams;
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(AsTool::class)]
 #[UsesClass(Metadata::class)]
 #[UsesClass(ParameterAnalyzer::class)]
-#[UsesClass(ToolParameter::class)]
+#[UsesClass(With::class)]
 final class ParameterAnalyzerTest extends TestCase
 {
     private ParameterAnalyzer $analyzer;

--- a/tests/Fixture/Tool/ToolWithToolParameterAttribute.php
+++ b/tests/Fixture/Tool/ToolWithToolParameterAttribute.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Tests\Fixture\Tool;
 
 use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
-use PhpLlm\LlmChain\Chain\ToolBox\Attribute\ToolParameter;
+use PhpLlm\LlmChain\Chain\ToolBox\Attribute\With;
 
 #[AsTool('tool_with_ToolParameter_attribute', 'A tool which has a parameter with described with #[ToolParameter] attribute')]
 final class ToolWithToolParameterAttribute
@@ -21,29 +21,21 @@ final class ToolWithToolParameterAttribute
      * @param object $shippingAddress  The shipping address given to the tool
      */
     public function __invoke(
-        #[ToolParameter(
-            enum: ['dog', 'cat', 'bird'],
-        )]
+        #[With(enum: ['dog', 'cat', 'bird'])]
         string $animal,
-        #[ToolParameter(
-            const: 42,
-        )]
+        #[With(const: 42)]
         int $numberOfArticles,
-        #[ToolParameter(
-            const: 'info@example.de',
-        )]
+        #[With(const: 'info@example.de')]
         string $infoEmail,
-        #[ToolParameter(
-            const: ['de', 'en'],
-        )]
+        #[With(const: ['de', 'en'])]
         string $locales,
-        #[ToolParameter(
+        #[With(
             pattern: '^[a-zA-Z]+$',
             minLength: 1,
             maxLength: 10,
         )]
         string $text,
-        #[ToolParameter(
+        #[With(
             minimum: 1,
             maximum: 10,
             multipleOf: 2,
@@ -51,7 +43,7 @@ final class ToolWithToolParameterAttribute
             exclusiveMaximum: 10,
         )]
         int $number,
-        #[ToolParameter(
+        #[With(
             minItems: 1,
             maxItems: 10,
             uniqueItems: true,
@@ -59,7 +51,7 @@ final class ToolWithToolParameterAttribute
             maxContains: 10,
         )]
         array $products,
-        #[ToolParameter(
+        #[With(
             required: true,
             minProperties: 1,
             maxProperties: 10,


### PR DESCRIPTION
Pulled out of #212 for a more neutral name also usable with DTO for structured output