### PR TITLE
fix: handle void|null tool response graceful

### DIFF
--- a/src/Chain/ToolBox/ToolResultConverter.php
+++ b/src/Chain/ToolBox/ToolResultConverter.php
@@ -6,13 +6,20 @@ namespace PhpLlm\LlmChain\Chain\ToolBox;
 
 final readonly class ToolResultConverter
 {
-    public function convert(mixed $result): string
+    /**
+     * @param \JsonSerializable|\Stringable|array<int|string, mixed>|float|string|null $result
+     */
+    public function convert(\JsonSerializable|\Stringable|array|float|string|null $result): ?string
     {
+        if (null === $result) {
+            return null;
+        }
+
         if ($result instanceof \JsonSerializable || is_array($result)) {
             return json_encode($result, flags: JSON_THROW_ON_ERROR);
         }
 
-        if (is_integer($result) || is_float($result) || $result instanceof \Stringable) {
+        if (is_float($result) || $result instanceof \Stringable) {
             return (string) $result;
         }
 

--- a/tests/Chain/ToolBox/ToolResultConverterTest.php
+++ b/tests/Chain/ToolBox/ToolResultConverterTest.php
@@ -15,7 +15,7 @@ final class ToolResultConverterTest extends TestCase
 {
     #[Test]
     #[DataProvider('provideResults')]
-    public function testConvert(mixed $result, string $expected): void
+    public function testConvert(mixed $result, ?string $expected): void
     {
         $converter = new ToolResultConverter();
 
@@ -24,6 +24,8 @@ final class ToolResultConverterTest extends TestCase
 
     public static function provideResults(): \Generator
     {
+        yield 'null' => [null, null];
+
         yield 'integer' => [42, '42'];
 
         yield 'float' => [42.42, '42.42'];


### PR DESCRIPTION
Breaking Change by limiting the tool result from `mixed` to actually supported types.