### PR TITLE
refactor: remove tool metadata class awareness

### DIFF
--- a/src/Chain/ToolBox/Metadata.php
+++ b/src/Chain/ToolBox/Metadata.php
@@ -15,7 +15,6 @@ final readonly class Metadata implements \JsonSerializable
      * @param JsonSchema|null $parameters
      */
     public function __construct(
-        public string $className,
         public string $name,
         public string $description,
         public string $method,

--- a/src/Chain/ToolBox/MetadataFactory/ReflectionFactory.php
+++ b/src/Chain/ToolBox/MetadataFactory/ReflectionFactory.php
@@ -45,7 +45,6 @@ final readonly class ReflectionFactory implements MetadataFactory
     {
         try {
             return new Metadata(
-                $className,
                 $attribute->name,
                 $attribute->description,
                 $attribute->method,

--- a/tests/Chain/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/tests/Chain/InputProcessor/SystemPromptInputProcessorTest.php
@@ -15,8 +15,6 @@ use PhpLlm\LlmChain\Model\Message\MessageBag;
 use PhpLlm\LlmChain\Model\Message\SystemMessage;
 use PhpLlm\LlmChain\Model\Message\UserMessage;
 use PhpLlm\LlmChain\Model\Response\ToolCall;
-use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolNoParams;
-use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolRequiredParams;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\Test;
@@ -105,9 +103,8 @@ final class SystemPromptInputProcessorTest extends TestCase
                 public function getMap(): array
                 {
                     return [
-                        new Metadata(ToolNoParams::class, 'tool_no_params', 'A tool without parameters', '__invoke', null),
+                        new Metadata('tool_no_params', 'A tool without parameters', '__invoke', null),
                         new Metadata(
-                            ToolRequiredParams::class,
                             'tool_required_params',
                             <<<DESCRIPTION
                                 A tool with required parameters

--- a/tests/Chain/ToolBox/ChainProcessorTest.php
+++ b/tests/Chain/ToolBox/ChainProcessorTest.php
@@ -43,8 +43,8 @@ class ChainProcessorTest extends TestCase
     public function processInputWithRegisteredToolsWillResultInOptionChange(): void
     {
         $toolBox = $this->createStub(ToolBoxInterface::class);
-        $tool1 = new Metadata('ClassTool1', 'tool1', 'description1', 'method1', null);
-        $tool2 = new Metadata('ClassTool2', 'tool2', 'description2', 'method2', null);
+        $tool1 = new Metadata('tool1', 'description1', 'method1', null);
+        $tool2 = new Metadata('tool2', 'description2', 'method2', null);
         $toolBox->method('getMap')->willReturn([$tool1, $tool2]);
 
         $llm = $this->createMock(LanguageModel::class);
@@ -62,8 +62,8 @@ class ChainProcessorTest extends TestCase
     public function processInputWithRegisteredToolsButToolOverride(): void
     {
         $toolBox = $this->createStub(ToolBoxInterface::class);
-        $tool1 = new Metadata('ClassTool1', 'tool1', 'description1', 'method1', null);
-        $tool2 = new Metadata('ClassTool2', 'tool2', 'description2', 'method2', null);
+        $tool1 = new Metadata('tool1', 'description1', 'method1', null);
+        $tool2 = new Metadata('tool2', 'description2', 'method2', null);
         $toolBox->method('getMap')->willReturn([$tool1, $tool2]);
 
         $llm = $this->createMock(LanguageModel::class);

--- a/tests/Chain/ToolBox/FaultTolerantToolBoxTest.php
+++ b/tests/Chain/ToolBox/FaultTolerantToolBoxTest.php
@@ -10,8 +10,6 @@ use PhpLlm\LlmChain\Chain\ToolBox\FaultTolerantToolBox;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
 use PhpLlm\LlmChain\Model\Response\ToolCall;
-use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolNoParams;
-use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolRequiredParams;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -69,8 +67,8 @@ final class FaultTolerantToolBoxTest extends TestCase
             public function getMap(): array
             {
                 return [
-                    new Metadata(ToolNoParams::class, 'tool_no_params', 'A tool without parameters', '__invoke', null),
-                    new Metadata(ToolRequiredParams::class, 'tool_required_params', 'A tool with required parameters', 'bar', null),
+                    new Metadata('tool_no_params', 'A tool without parameters', '__invoke', null),
+                    new Metadata('tool_required_params', 'A tool with required parameters', 'bar', null),
                 ];
             }
 

--- a/tests/Chain/ToolBox/MetadataFactory/ReflectionFactoryTest.php
+++ b/tests/Chain/ToolBox/MetadataFactory/ReflectionFactoryTest.php
@@ -69,7 +69,6 @@ final class ReflectionFactoryTest extends TestCase
 
         self::assertToolConfiguration(
             metadata: $metadatas[0],
-            className: ToolRequiredParams::class,
             name: 'tool_required_params',
             description: 'A tool with required parameters',
             method: 'bar',
@@ -102,7 +101,6 @@ final class ReflectionFactoryTest extends TestCase
 
         self::assertToolConfiguration(
             metadata: $first,
-            className: ToolMultiple::class,
             name: 'tool_hello_world',
             description: 'Function to say hello',
             method: 'hello',
@@ -121,7 +119,6 @@ final class ReflectionFactoryTest extends TestCase
 
         self::assertToolConfiguration(
             metadata: $second,
-            className: ToolMultiple::class,
             name: 'tool_required_params',
             description: 'Function to say a number',
             method: 'bar',
@@ -143,9 +140,8 @@ final class ReflectionFactoryTest extends TestCase
         );
     }
 
-    private function assertToolConfiguration(Metadata $metadata, string $className, string $name, string $description, string $method, array $parameters): void
+    private function assertToolConfiguration(Metadata $metadata, string $name, string $description, string $method, array $parameters): void
     {
-        self::assertSame($className, $metadata->className);
         self::assertSame($name, $metadata->name);
         self::assertSame($description, $metadata->description);
         self::assertSame($method, $metadata->method);


### PR DESCRIPTION
Especially with MCP the tool doesn't have to be a class and it was actually not used.