### PR TITLE
refactor: introduce execution reference in tool metadata

### DIFF
--- a/src/Chain/ToolBox/Exception/ToolNotFoundException.php
+++ b/src/Chain/ToolBox/Exception/ToolNotFoundException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Chain\ToolBox\Exception;
 
+use PhpLlm\LlmChain\Chain\ToolBox\ExecutionReference;
 use PhpLlm\LlmChain\Model\Response\ToolCall;
 
 final class ToolNotFoundException extends \RuntimeException implements ExceptionInterface
@@ -16,5 +17,10 @@ final class ToolNotFoundException extends \RuntimeException implements Exception
         $exception->toolCall = $toolCall;
 
         return $exception;
+    }
+
+    public static function notFoundForReference(ExecutionReference $reference): self
+    {
+        return new self(sprintf('Tool not found for reference: %s::%s.', $reference->class, $reference->method));
     }
 }

--- a/src/Chain/ToolBox/ExecutionReference.php
+++ b/src/Chain/ToolBox/ExecutionReference.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Chain\ToolBox;
+
+final class ExecutionReference
+{
+    public function __construct(
+        public string $class,
+        public string $method = '__invoke',
+    ) {
+    }
+}

--- a/src/Chain/ToolBox/Metadata.php
+++ b/src/Chain/ToolBox/Metadata.php
@@ -15,10 +15,9 @@ final readonly class Metadata implements \JsonSerializable
      * @param JsonSchema|null $parameters
      */
     public function __construct(
-        public string $className,
+        public ExecutionReference $reference,
         public string $name,
         public string $description,
-        public string $method,
         public ?array $parameters,
     ) {
     }

--- a/src/Chain/ToolBox/MetadataFactory/ReflectionFactory.php
+++ b/src/Chain/ToolBox/MetadataFactory/ReflectionFactory.php
@@ -7,6 +7,7 @@ namespace PhpLlm\LlmChain\Chain\ToolBox\MetadataFactory;
 use PhpLlm\LlmChain\Chain\JsonSchema\Factory;
 use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
 use PhpLlm\LlmChain\Chain\ToolBox\Exception\ToolConfigurationException;
+use PhpLlm\LlmChain\Chain\ToolBox\ExecutionReference;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\MetadataFactory;
 
@@ -45,10 +46,9 @@ final readonly class ReflectionFactory implements MetadataFactory
     {
         try {
             return new Metadata(
-                $className,
+                new ExecutionReference($className, $attribute->method),
                 $attribute->name,
                 $attribute->description,
-                $attribute->method,
                 $this->factory->buildParameters($className, $attribute->method)
             );
         } catch (\ReflectionException) {

--- a/tests/Chain/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/tests/Chain/InputProcessor/SystemPromptInputProcessorTest.php
@@ -7,6 +7,7 @@ namespace PhpLlm\LlmChain\Tests\Chain\InputProcessor;
 use PhpLlm\LlmChain\Bridge\OpenAI\GPT;
 use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\InputProcessor\SystemPromptInputProcessor;
+use PhpLlm\LlmChain\Chain\ToolBox\ExecutionReference;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
 use PhpLlm\LlmChain\Model\Message\Content\Text;
@@ -106,15 +107,14 @@ final class SystemPromptInputProcessorTest extends TestCase
                 public function getMap(): array
                 {
                     return [
-                        new Metadata(ToolNoParams::class, 'tool_no_params', 'A tool without parameters', '__invoke', null),
+                        new Metadata(new ExecutionReference(ToolNoParams::class), 'tool_no_params', 'A tool without parameters', null),
                         new Metadata(
-                            ToolRequiredParams::class,
+                            new ExecutionReference(ToolRequiredParams::class, 'bar'),
                             'tool_required_params',
                             <<<DESCRIPTION
                                 A tool with required parameters
                                 or not
                                 DESCRIPTION,
-                            'bar',
                             null
                         ),
                     ];

--- a/tests/Chain/ToolBox/ChainProcessorTest.php
+++ b/tests/Chain/ToolBox/ChainProcessorTest.php
@@ -6,6 +6,7 @@ namespace PhpLlm\LlmChain\Tests\Chain\ToolBox;
 
 use PhpLlm\LlmChain\Chain\Input;
 use PhpLlm\LlmChain\Chain\ToolBox\ChainProcessor;
+use PhpLlm\LlmChain\Chain\ToolBox\ExecutionReference;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
 use PhpLlm\LlmChain\Exception\MissingModelSupport;
@@ -44,8 +45,8 @@ class ChainProcessorTest extends TestCase
     public function processInputWithRegisteredToolsWillResultInOptionChange(): void
     {
         $toolBox = $this->createStub(ToolBoxInterface::class);
-        $tool1 = new Metadata('ClassTool1', 'tool1', 'description1', 'method1', null);
-        $tool2 = new Metadata('ClassTool2', 'tool2', 'description2', 'method2', null);
+        $tool1 = new Metadata(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
+        $tool2 = new Metadata(new ExecutionReference('ClassTool2', 'method1'), 'tool2', 'description2', null);
         $toolBox->method('getMap')->willReturn([$tool1, $tool2]);
 
         $llm = $this->createMock(LanguageModel::class);
@@ -63,8 +64,8 @@ class ChainProcessorTest extends TestCase
     public function processInputWithRegisteredToolsButToolOverride(): void
     {
         $toolBox = $this->createStub(ToolBoxInterface::class);
-        $tool1 = new Metadata('ClassTool1', 'tool1', 'description1', 'method1', null);
-        $tool2 = new Metadata('ClassTool2', 'tool2', 'description2', 'method2', null);
+        $tool1 = new Metadata(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
+        $tool2 = new Metadata(new ExecutionReference('ClassTool2', 'method1'), 'tool2', 'description2', null);
         $toolBox->method('getMap')->willReturn([$tool1, $tool2]);
 
         $llm = $this->createMock(LanguageModel::class);

--- a/tests/Chain/ToolBox/FaultTolerantToolBoxTest.php
+++ b/tests/Chain/ToolBox/FaultTolerantToolBoxTest.php
@@ -6,6 +6,7 @@ namespace PhpLlm\LlmChain\Tests\Chain\ToolBox;
 
 use PhpLlm\LlmChain\Chain\ToolBox\Exception\ToolExecutionException;
 use PhpLlm\LlmChain\Chain\ToolBox\Exception\ToolNotFoundException;
+use PhpLlm\LlmChain\Chain\ToolBox\ExecutionReference;
 use PhpLlm\LlmChain\Chain\ToolBox\FaultTolerantToolBox;
 use PhpLlm\LlmChain\Chain\ToolBox\Metadata;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBoxInterface;
@@ -69,8 +70,8 @@ final class FaultTolerantToolBoxTest extends TestCase
             public function getMap(): array
             {
                 return [
-                    new Metadata(ToolNoParams::class, 'tool_no_params', 'A tool without parameters', '__invoke', null),
-                    new Metadata(ToolRequiredParams::class, 'tool_required_params', 'A tool with required parameters', 'bar', null),
+                    new Metadata(new ExecutionReference(ToolNoParams::class), 'tool_no_params', 'A tool without parameters', null),
+                    new Metadata(new ExecutionReference(ToolRequiredParams::class, 'bar'), 'tool_required_params', 'A tool with required parameters', null),
                 ];
             }
 

--- a/tests/Chain/ToolBox/MetadataFactory/ReflectionFactoryTest.php
+++ b/tests/Chain/ToolBox/MetadataFactory/ReflectionFactoryTest.php
@@ -145,10 +145,10 @@ final class ReflectionFactoryTest extends TestCase
 
     private function assertToolConfiguration(Metadata $metadata, string $className, string $name, string $description, string $method, array $parameters): void
     {
-        self::assertSame($className, $metadata->className);
+        self::assertSame($className, $metadata->reference->class);
+        self::assertSame($method, $metadata->reference->method);
         self::assertSame($name, $metadata->name);
         self::assertSame($description, $metadata->description);
-        self::assertSame($method, $metadata->method);
         self::assertSame($parameters, $metadata->parameters);
     }
 }


### PR DESCRIPTION
replaces #255 if successful

motivation: the execution reference is a pointer what the toolbox needs to execute. classname + method is only one type - with MCP it could also be a server + toolname.