### PR TITLE
feat: Add Raw Response Metadata Handling - GPT Token Usage Example

### DIFF
--- a/examples/chat-gpt-openai-metadata.php
+++ b/examples/chat-gpt-openai-metadata.php
@@ -1,0 +1,38 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Bridge\OpenAI\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\OpenAI\TokenOutputProcessor;
+use PhpLlm\LlmChain\Chain;
+use PhpLlm\LlmChain\Model\Message\Message;
+use PhpLlm\LlmChain\Model\Message\MessageBag;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+
+if (empty($_ENV['OPENAI_API_KEY'])) {
+    echo 'Please set the OPENAI_API_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+$llm = new GPT(GPT::GPT_4O_MINI, [
+    'temperature' => 0.5, // default options for the model
+]);
+
+$chain = new Chain($platform, $llm, outputProcessors: [new TokenOutputProcessor()]);
+$messages = new MessageBag(
+    Message::forSystem('You are a pirate and you write funny.'),
+    Message::ofUser('What is the Symfony framework?'),
+);
+$response = $chain->call($messages, [
+    'max_tokens' => 500, // specific options just for this call
+]);
+
+$metadata = $response->getMetadata();
+
+echo 'Utilized Tokens: '.$metadata['total_tokens'].PHP_EOL;
+echo '-- Prompt Tokens: '.$metadata['prompt_tokens'].PHP_EOL;
+echo '-- Completion Tokens: '.$metadata['completion_tokens'].PHP_EOL;
+echo 'Remaining Tokens: '.$metadata['remaining_tokens'].PHP_EOL;

--- a/src/Bridge/OpenAI/DallE/ImageResponse.php
+++ b/src/Bridge/OpenAI/DallE/ImageResponse.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Bridge\OpenAI\DallE;
 
-use PhpLlm\LlmChain\Model\Response\ResponseInterface;
+use PhpLlm\LlmChain\Model\Response\BaseResponse;
 
-class ImageResponse implements ResponseInterface
+class ImageResponse extends BaseResponse
 {
     /** @var list<Base64Image|UrlImage> */
     private readonly array $images;

--- a/src/Bridge/OpenAI/TokenOutputProcessor.php
+++ b/src/Bridge/OpenAI/TokenOutputProcessor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\OpenAI;
+
+use PhpLlm\LlmChain\Chain\Output;
+use PhpLlm\LlmChain\Chain\OutputProcessor;
+use PhpLlm\LlmChain\Model\Response\StreamResponse;
+
+final class TokenOutputProcessor implements OutputProcessor
+{
+    public function processOutput(Output $output): void
+    {
+        if ($output->response instanceof StreamResponse) {
+            // Streams have to be handled manually as the tokens are part of the streamed chunks
+            return;
+        }
+
+        $rawResponse = $output->response->getRawResponse();
+        if (null === $rawResponse) {
+            return;
+        }
+
+        $metadata = $output->response->getMetadata();
+
+        $metadata->add(
+            'remaining_tokens',
+            (int) $rawResponse->getHeaders(false)['x-ratelimit-remaining-tokens'][0],
+        );
+
+        $content = $rawResponse->toArray(false);
+
+        if (!\array_key_exists('usage', $content)) {
+            return;
+        }
+
+        $metadata->add('prompt_tokens', $content['usage']['prompt_tokens'] ?? null);
+        $metadata->add('completion_tokens', $content['usage']['completion_tokens'] ?? null);
+        $metadata->add('total_tokens', $content['usage']['total_tokens'] ?? null);
+    }
+}

--- a/src/Chain/Toolbox/StreamResponse.php
+++ b/src/Chain/Toolbox/StreamResponse.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChain\Chain\Toolbox;
 
 use PhpLlm\LlmChain\Model\Message\Message;
-use PhpLlm\LlmChain\Model\Response\ResponseInterface;
+use PhpLlm\LlmChain\Model\Response\BaseResponse;
 use PhpLlm\LlmChain\Model\Response\ToolCallResponse;
 
-final readonly class StreamResponse implements ResponseInterface
+final class StreamResponse extends BaseResponse
 {
     public function __construct(
-        private \Generator $generator,
-        private \Closure $handleToolCallsCallback,
+        private readonly \Generator $generator,
+        private readonly \Closure $handleToolCallsCallback,
     ) {
     }
 

--- a/src/Model/Response/BaseResponse.php
+++ b/src/Model/Response/BaseResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response;
+
+use PhpLlm\LlmChain\Model\Response\Metadata\MetadataAwareTrait;
+
+abstract class BaseResponse implements ResponseInterface
+{
+    use MetadataAwareTrait;
+    use RawResponseAwareTrait;
+}

--- a/src/Model/Response/BinaryResponse.php
+++ b/src/Model/Response/BinaryResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Response;
 
-final class BinaryResponse implements ResponseInterface
+final class BinaryResponse extends BaseResponse
 {
     public function __construct(
         public string $data,

--- a/src/Model/Response/ChoiceResponse.php
+++ b/src/Model/Response/ChoiceResponse.php
@@ -6,12 +6,12 @@ namespace PhpLlm\LlmChain\Model\Response;
 
 use PhpLlm\LlmChain\Exception\InvalidArgumentException;
 
-final readonly class ChoiceResponse implements ResponseInterface
+final class ChoiceResponse extends BaseResponse
 {
     /**
      * @var Choice[]
      */
-    private array $choices;
+    private readonly array $choices;
 
     public function __construct(Choice ...$choices)
     {

--- a/src/Model/Response/Exception/RawResponseAlreadySet.php
+++ b/src/Model/Response/Exception/RawResponseAlreadySet.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response\Exception;
+
+final class RawResponseAlreadySet extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The raw response was already set.');
+    }
+}

--- a/src/Model/Response/Metadata/Metadata.php
+++ b/src/Model/Response/Metadata/Metadata.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response\Metadata;
+
+/**
+ * @implements \IteratorAggregate<string, mixed>
+ * @implements \ArrayAccess<string, mixed>
+ */
+class Metadata implements \JsonSerializable, \Countable, \IteratorAggregate, \ArrayAccess
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $metadata = [];
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(array $metadata = [])
+    {
+        $this->set($metadata);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function set(array $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function add(string $key, mixed $value): void
+    {
+        $this->metadata[$key] = $value;
+    }
+
+    public function has(string $key): bool
+    {
+        return \array_key_exists($key, $this->metadata);
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->metadata[$key] ?? $default;
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->metadata[$key]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->all();
+    }
+
+    public function count(): int
+    {
+        return \count($this->metadata);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->metadata);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->has((string) $offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get((string) $offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->add((string) $offset, $value);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->remove((string) $offset);
+    }
+}

--- a/src/Model/Response/Metadata/MetadataAwareTrait.php
+++ b/src/Model/Response/Metadata/MetadataAwareTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response\Metadata;
+
+trait MetadataAwareTrait
+{
+    private ?Metadata $metadata = null;
+
+    public function getMetadata(): Metadata
+    {
+        if (null === $this->metadata) {
+            $this->metadata = new Metadata();
+        }
+
+        return $this->metadata;
+    }
+}

--- a/src/Model/Response/Metadata/MetadataAwareTrait.php
+++ b/src/Model/Response/Metadata/MetadataAwareTrait.php
@@ -10,10 +10,6 @@ trait MetadataAwareTrait
 
     public function getMetadata(): Metadata
     {
-        if (null === $this->metadata) {
-            $this->metadata = new Metadata();
-        }
-
-        return $this->metadata;
+        return $this->metadata ??= new Metadata();
     }
 }

--- a/src/Model/Response/RawResponseAwareTrait.php
+++ b/src/Model/Response/RawResponseAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response;
+
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
+trait RawResponseAwareTrait
+{
+    protected ?SymfonyHttpResponse $rawResponse = null;
+
+    public function setRawResponse(SymfonyHttpResponse $rawResponse): void
+    {
+        if (null !== $this->rawResponse) {
+            throw new RawResponseAlreadySet();
+        }
+
+        $this->rawResponse = $rawResponse;
+    }
+
+    public function getRawResponse(): ?SymfonyHttpResponse
+    {
+        return $this->rawResponse;
+    }
+}

--- a/src/Model/Response/ResponseInterface.php
+++ b/src/Model/Response/ResponseInterface.php
@@ -4,10 +4,23 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Response;
 
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use PhpLlm\LlmChain\Model\Response\Metadata\Metadata;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
 interface ResponseInterface
 {
     /**
      * @return string|iterable<mixed>|object|null
      */
     public function getContent(): string|iterable|object|null;
+
+    public function getMetadata(): Metadata;
+
+    public function getRawResponse(): ?SymfonyHttpResponse;
+
+    /**
+     * @throws RawResponseAlreadySet if the response is tried to be set more than once
+     */
+    public function setRawResponse(SymfonyHttpResponse $rawResponse): void;
 }

--- a/src/Model/Response/StreamResponse.php
+++ b/src/Model/Response/StreamResponse.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Response;
 
-final readonly class StreamResponse implements ResponseInterface
+final class StreamResponse extends BaseResponse
 {
     public function __construct(
-        private \Generator $generator,
+        private readonly \Generator $generator,
     ) {
     }
 

--- a/src/Model/Response/StructuredResponse.php
+++ b/src/Model/Response/StructuredResponse.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Response;
 
-final readonly class StructuredResponse implements ResponseInterface
+final class StructuredResponse extends BaseResponse
 {
     /**
      * @param object|array<string, mixed> $structuredOutput
      */
     public function __construct(
-        private object|array $structuredOutput,
+        private readonly object|array $structuredOutput,
     ) {
     }
 

--- a/src/Model/Response/TextResponse.php
+++ b/src/Model/Response/TextResponse.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChain\Model\Response;
 
-final readonly class TextResponse implements ResponseInterface
+final class TextResponse extends BaseResponse
 {
     public function __construct(
-        private string $content,
+        private readonly string $content,
     ) {
     }
 

--- a/src/Model/Response/ToolCallResponse.php
+++ b/src/Model/Response/ToolCallResponse.php
@@ -6,12 +6,12 @@ namespace PhpLlm\LlmChain\Model\Response;
 
 use PhpLlm\LlmChain\Exception\InvalidArgumentException;
 
-final readonly class ToolCallResponse implements ResponseInterface
+final class ToolCallResponse extends BaseResponse
 {
     /**
      * @var ToolCall[]
      */
-    private array $toolCalls;
+    private readonly array $toolCalls;
 
     public function __construct(ToolCall ...$toolCalls)
     {

--- a/src/Model/Response/VectorResponse.php
+++ b/src/Model/Response/VectorResponse.php
@@ -6,12 +6,12 @@ namespace PhpLlm\LlmChain\Model\Response;
 
 use PhpLlm\LlmChain\Document\Vector;
 
-final readonly class VectorResponse implements ResponseInterface
+final class VectorResponse extends BaseResponse
 {
     /**
      * @var Vector[]
      */
-    private array $vectors;
+    private readonly array $vectors;
 
     public function __construct(Vector ...$vector)
     {

--- a/tests/Bridge/OpenAI/TokenOutputProcessorTest.php
+++ b/tests/Bridge/OpenAI/TokenOutputProcessorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Bridge\OpenAI;
+
+use PhpLlm\LlmChain\Bridge\OpenAI\TokenOutputProcessor;
+use PhpLlm\LlmChain\Chain\Output;
+use PhpLlm\LlmChain\Model\LanguageModel;
+use PhpLlm\LlmChain\Model\Message\MessageBagInterface;
+use PhpLlm\LlmChain\Model\Response\Metadata\Metadata;
+use PhpLlm\LlmChain\Model\Response\ResponseInterface;
+use PhpLlm\LlmChain\Model\Response\StreamResponse;
+use PhpLlm\LlmChain\Model\Response\TextResponse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
+#[CoversClass(TokenOutputProcessor::class)]
+#[UsesClass(Output::class)]
+#[UsesClass(TextResponse::class)]
+#[UsesClass(StreamResponse::class)]
+#[UsesClass(Metadata::class)]
+#[UsesClass(SymfonyHttpResponse::class)]
+#[Small]
+final class TokenOutputProcessorTest extends TestCase
+{
+    #[Test]
+    public function itHandlesStreamResponsesWithoutProcessing(): void
+    {
+        $processor = new TokenOutputProcessor();
+        $streamResponse = new StreamResponse((static function () { yield 'test'; })());
+        $output = $this->createOutput($streamResponse);
+
+        $processor->processOutput($output);
+
+        $metadata = $output->response->getMetadata();
+        self::assertCount(0, $metadata);
+    }
+
+    #[Test]
+    public function itDoesNothingWithoutRawResponse(): void
+    {
+        $processor = new TokenOutputProcessor();
+        $textResponse = new TextResponse('test');
+        $output = $this->createOutput($textResponse);
+
+        $processor->processOutput($output);
+
+        $metadata = $output->response->getMetadata();
+        self::assertCount(0, $metadata);
+    }
+
+    #[Test]
+    public function itAddsRemainingTokensToMetadata(): void
+    {
+        $processor = new TokenOutputProcessor();
+        $textResponse = new TextResponse('test');
+
+        $rawResponse = self::createStub(SymfonyHttpResponse::class);
+        $rawResponse->method('getHeaders')->willReturn([
+            'x-ratelimit-remaining-tokens' => ['1000'],
+        ]);
+        $rawResponse->method('toArray')->willReturn([]);
+
+        $textResponse->setRawResponse($rawResponse);
+
+        $output = $this->createOutput($textResponse);
+
+        $processor->processOutput($output);
+
+        $metadata = $output->response->getMetadata();
+        self::assertCount(1, $metadata);
+        self::assertSame(1000, $metadata->get('remaining_tokens'));
+    }
+
+    #[Test]
+    public function itAddsUsageTokensToMetadata(): void
+    {
+        $processor = new TokenOutputProcessor();
+        $textResponse = new TextResponse('test');
+
+        $rawResponse = self::createStub(SymfonyHttpResponse::class);
+        $rawResponse->method('getHeaders')->willReturn([
+            'x-ratelimit-remaining-tokens' => ['1000'],
+        ]);
+        $rawResponse->method('toArray')->willReturn([
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 20,
+                'total_tokens' => 30,
+            ],
+        ]);
+
+        $textResponse->setRawResponse($rawResponse);
+
+        $output = $this->createOutput($textResponse);
+
+        $processor->processOutput($output);
+
+        $metadata = $output->response->getMetadata();
+        self::assertCount(4, $metadata);
+        self::assertSame(1000, $metadata->get('remaining_tokens'));
+        self::assertSame(10, $metadata->get('prompt_tokens'));
+        self::assertSame(20, $metadata->get('completion_tokens'));
+        self::assertSame(30, $metadata->get('total_tokens'));
+    }
+
+    #[Test]
+    public function itHandlesMissingUsageFields(): void
+    {
+        $processor = new TokenOutputProcessor();
+        $textResponse = new TextResponse('test');
+
+        $rawResponse = self::createStub(SymfonyHttpResponse::class);
+        $rawResponse->method('getHeaders')->willReturn([
+            'x-ratelimit-remaining-tokens' => ['1000'],
+        ]);
+        $rawResponse->method('toArray')->willReturn([
+            'usage' => [
+                // Missing some fields
+                'prompt_tokens' => 10,
+            ],
+        ]);
+
+        $textResponse->setRawResponse($rawResponse);
+
+        $output = $this->createOutput($textResponse);
+
+        $processor->processOutput($output);
+
+        $metadata = $output->response->getMetadata();
+        self::assertCount(4, $metadata);
+        self::assertSame(1000, $metadata->get('remaining_tokens'));
+        self::assertSame(10, $metadata->get('prompt_tokens'));
+        self::assertNull($metadata->get('completion_tokens'));
+        self::assertNull($metadata->get('total_tokens'));
+    }
+
+    private function createOutput(ResponseInterface $response): Output
+    {
+        return new Output(
+            self::createStub(LanguageModel::class),
+            $response,
+            self::createStub(MessageBagInterface::class),
+            [],
+        );
+    }
+}

--- a/tests/Model/Response/AsyncResponseTest.php
+++ b/tests/Model/Response/AsyncResponseTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response;
+
+use PhpLlm\LlmChain\Model\Response\AsyncResponse;
+use PhpLlm\LlmChain\Model\Response\BaseResponse;
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use PhpLlm\LlmChain\Model\Response\Metadata\Metadata;
+use PhpLlm\LlmChain\Model\Response\ResponseInterface;
+use PhpLlm\LlmChain\Model\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\ResponseConverter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
+#[CoversClass(AsyncResponse::class)]
+#[UsesClass(Metadata::class)]
+#[UsesClass(TextResponse::class)]
+#[UsesClass(RawResponseAlreadySet::class)]
+#[Small]
+final class AsyncResponseTest extends TestCase
+{
+    #[Test]
+    public function itUnwrapsTheResponseWhenGettingContent(): void
+    {
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $textResponse = new TextResponse('test content');
+
+        $responseConverter = $this->createMock(ResponseConverter::class);
+        $responseConverter->expects($this->once())
+            ->method('convert')
+            ->with($httpResponse, [])
+            ->willReturn($textResponse);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse);
+
+        self::assertSame('test content', $asyncResponse->getContent());
+    }
+
+    #[Test]
+    public function itConvertsTheResponseOnlyOnce(): void
+    {
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $textResponse = new TextResponse('test content');
+
+        $responseConverter = $this->createMock(ResponseConverter::class);
+        $responseConverter->expects($this->once())
+            ->method('convert')
+            ->with($httpResponse, [])
+            ->willReturn($textResponse);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse);
+
+        // Call unwrap multiple times, but the converter should only be called once
+        $asyncResponse->unwrap();
+        $asyncResponse->unwrap();
+        $asyncResponse->getContent();
+    }
+
+    #[Test]
+    public function itGetsRawResponseDirectly(): void
+    {
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $responseConverter = $this->createStub(ResponseConverter::class);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse);
+
+        self::assertSame($httpResponse, $asyncResponse->getRawResponse());
+    }
+
+    #[Test]
+    public function itThrowsExceptionWhenSettingRawResponse(): void
+    {
+        $this->expectException(RawResponseAlreadySet::class);
+
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $responseConverter = $this->createStub(ResponseConverter::class);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse);
+        $asyncResponse->setRawResponse($httpResponse);
+    }
+
+    #[Test]
+    public function itSetsRawResponseOnUnwrappedResponseWhenNeeded(): void
+    {
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+
+        $unwrappedResponse = $this->createResponse(null);
+
+        $responseConverter = $this->createStub(ResponseConverter::class);
+        $responseConverter->method('convert')->willReturn($unwrappedResponse);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse);
+        $asyncResponse->unwrap();
+
+        // The raw response in the model response is now set and not null anymore
+        self::assertSame($httpResponse, $unwrappedResponse->getRawResponse());
+    }
+
+    #[Test]
+    public function itDoesNotSetRawResponseOnUnwrappedResponseWhenAlreadySet(): void
+    {
+        $originHttpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $anotherHttpResponse = $this->createStub(SymfonyHttpResponse::class);
+
+        $unwrappedResponse = $this->createResponse($anotherHttpResponse);
+
+        $responseConverter = $this->createStub(ResponseConverter::class);
+        $responseConverter->method('convert')->willReturn($unwrappedResponse);
+
+        $asyncResponse = new AsyncResponse($responseConverter, $originHttpResponse);
+        $asyncResponse->unwrap();
+
+        // It is still the same raw response as set initially and so not overwritten
+        self::assertSame($anotherHttpResponse, $unwrappedResponse->getRawResponse());
+    }
+
+    /**
+     * Workaround for low deps because mocking the ResponseInterface leads to an exception with
+     * mock creation "Type Traversable|object|array|string|null contains both object and a class type"
+     * in PHPUnit MockClass.
+     */
+    private function createResponse(?SymfonyHttpResponse $rawResponse): ResponseInterface
+    {
+        return new class($rawResponse) extends BaseResponse {
+            public function __construct(protected ?SymfonyHttpResponse $rawResponse)
+            {
+            }
+
+            public function getContent(): string
+            {
+                return 'test content';
+            }
+
+            public function getRawResponse(): ?SymfonyHttpResponse
+            {
+                return $this->rawResponse;
+            }
+        };
+    }
+
+    #[Test]
+    public function itPassesOptionsToConverter(): void
+    {
+        $httpResponse = $this->createStub(SymfonyHttpResponse::class);
+        $options = ['option1' => 'value1', 'option2' => 'value2'];
+
+        $responseConverter = $this->createMock(ResponseConverter::class);
+        $responseConverter->expects($this->once())
+            ->method('convert')
+            ->with($httpResponse, $options)
+            ->willReturn($this->createResponse(null));
+
+        $asyncResponse = new AsyncResponse($responseConverter, $httpResponse, $options);
+        $asyncResponse->unwrap();
+    }
+}

--- a/tests/Model/Response/BaseResponseTest.php
+++ b/tests/Model/Response/BaseResponseTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response;
+
+use PhpLlm\LlmChain\Model\Response\BaseResponse;
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use PhpLlm\LlmChain\Model\Response\Metadata\MetadataAwareTrait;
+use PhpLlm\LlmChain\Model\Response\RawResponseAwareTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
+#[CoversClass(BaseResponse::class)]
+#[UsesTrait(MetadataAwareTrait::class)]
+#[UsesTrait(RawResponseAwareTrait::class)]
+#[Small]
+final class BaseResponseTest extends TestCase
+{
+    #[Test]
+    public function itCanHandleMetadata(): void
+    {
+        $response = $this->createResponse();
+        $metadata = $response->getMetadata();
+
+        self::assertCount(0, $metadata);
+
+        $metadata->add('key', 'value');
+        $metadata = $response->getMetadata();
+
+        self::assertCount(1, $metadata);
+    }
+
+    #[Test]
+    public function itCanBeEnrichedWithARawResponse(): void
+    {
+        $response = $this->createResponse();
+        $rawResponse = $this->createMock(SymfonyHttpResponse::class);
+
+        $response->setRawResponse($rawResponse);
+        self::assertSame($rawResponse, $response->getRawResponse());
+    }
+
+    #[Test]
+    public function itThrowsAnExceptionWhenSettingARawResponseTwice(): void
+    {
+        $this->expectException(RawResponseAlreadySet::class);
+
+        $response = $this->createResponse();
+        $rawResponse = $this->createMock(SymfonyHttpResponse::class);
+
+        $response->setRawResponse($rawResponse);
+        $response->setRawResponse($rawResponse);
+    }
+
+    private function createResponse(): BaseResponse
+    {
+        return new class extends BaseResponse {
+            public function getContent(): string
+            {
+                return 'test';
+            }
+        };
+    }
+}

--- a/tests/Model/Response/Exception/RawResponseAlreadySetTest.php
+++ b/tests/Model/Response/Exception/RawResponseAlreadySetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response\Exception;
+
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RawResponseAlreadySet::class)]
+#[Small]
+final class RawResponseAlreadySetTest extends TestCase
+{
+    #[Test]
+    public function itHasCorrectExceptionMessage(): void
+    {
+        $exception = new RawResponseAlreadySet();
+
+        self::assertSame('The raw response was already set.', $exception->getMessage());
+    }
+}

--- a/tests/Model/Response/Metadata/MetadataAwareTraitTest.php
+++ b/tests/Model/Response/Metadata/MetadataAwareTraitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response\Metadata;
+
+use PhpLlm\LlmChain\Model\Response\Metadata\MetadataAwareTrait;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversTrait(MetadataAwareTrait::class)]
+#[Small]
+final class MetadataAwareTraitTest extends TestCase
+{
+    #[Test]
+    public function itCanHandleMetadata(): void
+    {
+        $response = $this->createTestClass();
+        $metadata = $response->getMetadata();
+
+        self::assertCount(0, $metadata);
+
+        $metadata->add('key', 'value');
+        $metadata = $response->getMetadata();
+
+        self::assertCount(1, $metadata);
+    }
+
+    private function createTestClass(): object
+    {
+        return new class {
+            use MetadataAwareTrait;
+        };
+    }
+}

--- a/tests/Model/Response/Metadata/MetadataTest.php
+++ b/tests/Model/Response/Metadata/MetadataTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response\Metadata;
+
+use PhpLlm\LlmChain\Model\Response\Metadata\Metadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Metadata::class)]
+#[Small]
+final class MetadataTest extends TestCase
+{
+    #[Test]
+    public function itCanBeCreatedEmpty(): void
+    {
+        $metadata = new Metadata();
+        self::assertCount(0, $metadata);
+        self::assertSame([], $metadata->all());
+    }
+
+    #[Test]
+    public function itCanBeCreatedWithInitialData(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+        self::assertCount(1, $metadata);
+        self::assertSame(['key' => 'value'], $metadata->all());
+    }
+
+    #[Test]
+    public function itCanAddNewMetadata(): void
+    {
+        $metadata = new Metadata();
+        $metadata->add('key', 'value');
+
+        self::assertTrue($metadata->has('key'));
+        self::assertSame('value', $metadata->get('key'));
+    }
+
+    #[Test]
+    public function itCanCheckIfMetadataExists(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+
+        self::assertTrue($metadata->has('key'));
+        self::assertFalse($metadata->has('nonexistent'));
+    }
+
+    #[Test]
+    public function itCanGetMetadataWithDefault(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+
+        self::assertSame('value', $metadata->get('key'));
+        self::assertSame('default', $metadata->get('nonexistent', 'default'));
+        self::assertNull($metadata->get('nonexistent'));
+    }
+
+    #[Test]
+    public function itCanRemoveMetadata(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+        self::assertTrue($metadata->has('key'));
+
+        $metadata->remove('key');
+        self::assertFalse($metadata->has('key'));
+    }
+
+    #[Test]
+    public function itCanSetEntireMetadataArray(): void
+    {
+        $metadata = new Metadata(['key1' => 'value1']);
+        $metadata->set(['key2' => 'value2', 'key3' => 'value3']);
+
+        self::assertFalse($metadata->has('key1'));
+        self::assertTrue($metadata->has('key2'));
+        self::assertTrue($metadata->has('key3'));
+        self::assertSame(['key2' => 'value2', 'key3' => 'value3'], $metadata->all());
+    }
+
+    #[Test]
+    public function itImplementsJsonSerializable(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+        self::assertSame(['key' => 'value'], $metadata->jsonSerialize());
+    }
+
+    #[Test]
+    public function itImplementsArrayAccess(): void
+    {
+        $metadata = new Metadata(['key' => 'value']);
+
+        self::assertArrayHasKey('key', $metadata);
+        self::assertSame('value', $metadata['key']);
+
+        $metadata['new'] = 'newValue';
+        self::assertSame('newValue', $metadata['new']);
+
+        unset($metadata['key']);
+        self::assertArrayNotHasKey('key', $metadata);
+    }
+
+    #[Test]
+    public function itImplementsIteratorAggregate(): void
+    {
+        $metadata = new Metadata(['key1' => 'value1', 'key2' => 'value2']);
+        $result = \iterator_to_array($metadata);
+
+        self::assertSame(['key1' => 'value1', 'key2' => 'value2'], $result);
+    }
+
+    #[Test]
+    public function itImplementsCountable(): void
+    {
+        $metadata = new Metadata();
+        self::assertCount(0, $metadata);
+
+        $metadata->add('key', 'value');
+        self::assertCount(1, $metadata);
+
+        $metadata->add('key2', 'value2');
+        self::assertCount(2, $metadata);
+
+        $metadata->remove('key');
+        self::assertCount(1, $metadata);
+    }
+}

--- a/tests/Model/Response/RawResponseAwareTraitTest.php
+++ b/tests/Model/Response/RawResponseAwareTraitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Model\Response;
+
+use PhpLlm\LlmChain\Model\Response\Exception\RawResponseAlreadySet;
+use PhpLlm\LlmChain\Model\Response\RawResponseAwareTrait;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
+
+#[CoversTrait(RawResponseAwareTrait::class)]
+#[Small]
+final class RawResponseAwareTraitTest extends TestCase
+{
+    #[Test]
+    public function itCanBeEnrichedWithARawResponse(): void
+    {
+        $response = $this->createTestClass();
+        $rawResponse = $this->createMock(SymfonyHttpResponse::class);
+
+        $response->setRawResponse($rawResponse);
+        self::assertSame($rawResponse, $response->getRawResponse());
+    }
+
+    #[Test]
+    public function itThrowsAnExceptionWhenSettingARawResponseTwice(): void
+    {
+        $this->expectException(RawResponseAlreadySet::class);
+
+        $response = $this->createTestClass();
+        $rawResponse = $this->createMock(SymfonyHttpResponse::class);
+
+        $response->setRawResponse($rawResponse);
+        $response->setRawResponse($rawResponse);
+    }
+
+    private function createTestClass(): object
+    {
+        return new class {
+            use RawResponseAwareTrait;
+        };
+    }
+}


### PR DESCRIPTION
Currently it is not really possible to get into details of the interaction between user and model because the HTTPResponse is hidden behind the response converter and is then forgotten forever. So the only possibility currently to get details from the interaction would be a custom response and a custom response converter. 

As a draft and to collect your ideas and other input i want to throw this stone into the lake with having the HTTPResponse also transported into the direction of the output processors. Could this give a bit more flexibility? What do you think? 

Please have in mind this is only a draft to discuss. I thought about having this also possible if a request fails with an error status code in the future so the output processors could handle in a separation of convern way if there should be an exception thrown. Or do we maybe need an additional layer on top of the response converters itself? 

For sure this is the simplest use case with the text response in mind. Maybe for the streamed response it would need a more "recording" approach with an output processor. But would surely be possible. 