### PR TITLE
ci: reorder qa pipeline to shift commit check to last step

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,13 +46,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Conventional Commit
-        uses: ytanikin/pr-conventional-commits@1.4.1
-        with:
-          task_types: '["feat", "fix", "docs", "test", "ci", "style", "refactor", "perf", "chore", "revert"]'
-          add_label: 'true'
-          custom_labels: '{"feat": "feature", "fix": "bug", "docs": "documentation", "test": "test", "ci": "CI/CD", "style": "codestyle", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert"}'
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -77,3 +70,10 @@ jobs:
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse
+
+      - name: Conventional Commit
+        uses: ytanikin/pr-conventional-commits@1.4.1
+        with:
+          task_types: '["feat", "fix", "docs", "test", "ci", "style", "refactor", "perf", "chore", "revert"]'
+          add_label: 'true'
+          custom_labels: '{"feat": "feature", "fix": "bug", "docs": "documentation", "test": "test", "ci": "CI/CD", "style": "codestyle", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert"}'


### PR DESCRIPTION
I think it's annoying to only see other tests if the commit message matches the format - besides the feedback, it's a good reminder for me to override the commit message while merging, but i want to have the results of other qa tests at hand than.