### PR TITLE
refactor: rename Model::version to Model::name

### DIFF
--- a/examples/chat-claude-anthropic.php
+++ b/examples/chat-claude-anthropic.php
@@ -16,7 +16,7 @@ if (empty($_ENV['ANTHROPIC_API_KEY'])) {
 }
 
 $platform = PlatformFactory::create($_ENV['ANTHROPIC_API_KEY']);
-$llm = new Claude(Claude::VERSION_37_SONNET);
+$llm = new Claude(Claude::SONNET_37);
 
 $chain = new Chain($platform, $llm);
 $messages = new MessageBag(

--- a/examples/chat-llama-azure.php
+++ b/examples/chat-llama-azure.php
@@ -16,7 +16,7 @@ if (empty($_ENV['AZURE_LLAMA_BASEURL']) || empty($_ENV['AZURE_LLAMA_KEY'])) {
 }
 
 $platform = PlatformFactory::create($_ENV['AZURE_LLAMA_BASEURL'], $_ENV['AZURE_LLAMA_KEY']);
-$llm = new Llama(Llama::LLAMA_3_3_70B_INSTRUCT);
+$llm = new Llama(Llama::V3_3_70B_INSTRUCT);
 
 $chain = new Chain($platform, $llm);
 $messages = new MessageBag(Message::ofUser('I am going to Paris, what should I see?'));

--- a/examples/image-generator-dall-e-3.php
+++ b/examples/image-generator-dall-e-3.php
@@ -17,7 +17,7 @@ if (empty($_ENV['OPENAI_API_KEY'])) {
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
 
 $response = $platform->request(
-    model: new DallE(version: DallE::DALL_E_3),
+    model: new DallE(name: DallE::DALL_E_3),
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
         'response_format' => 'url', // Generate response as URL

--- a/src/Bridge/Anthropic/Claude.php
+++ b/src/Bridge/Anthropic/Claude.php
@@ -8,26 +8,26 @@ use PhpLlm\LlmChain\Model\LanguageModel;
 
 final readonly class Claude implements LanguageModel
 {
-    public const VERSION_3_HAIKU = 'claude-3-haiku-20240307';
-    public const VERSION_35_HAIKU = 'claude-3-5-haiku-20241022';
-    public const VERSION_3_SONNET = 'claude-3-sonnet-20240229';
-    public const VERSION_35_SONNET = 'claude-3-5-sonnet-20240620';
-    public const VERSION_35_SONNET_V2 = 'claude-3-5-sonnet-20241022';
-    public const VERSION_37_SONNET = 'claude-3-7-sonnet-20250219';
-    public const VERSION_3_OPUS = 'claude-3-opus-20240229';
+    public const HAIKU_3 = 'claude-3-haiku-20240307';
+    public const HAIKU_35 = 'claude-3-5-haiku-20241022';
+    public const SONNET_3 = 'claude-3-sonnet-20240229';
+    public const SONNET_35 = 'claude-3-5-sonnet-20240620';
+    public const SONNET_35_V2 = 'claude-3-5-sonnet-20241022';
+    public const SONNET_37 = 'claude-3-7-sonnet-20250219';
+    public const OPUS_3 = 'claude-3-opus-20240229';
 
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
     public function __construct(
-        private string $version = self::VERSION_35_SONNET,
+        private string $name = self::SONNET_37,
         private array $options = ['temperature' => 1.0, 'max_tokens' => 1000],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/Anthropic/ModelHandler.php
+++ b/src/Bridge/Anthropic/ModelHandler.php
@@ -62,7 +62,7 @@ final readonly class ModelHandler implements ModelClient, ResponseConverter
         }
 
         $body = [
-            'model' => $model->getVersion(),
+            'model' => $model->getName(),
             'messages' => $input->withoutSystemMessage()->jsonSerialize(),
         ];
 

--- a/src/Bridge/Azure/Meta/LlamaHandler.php
+++ b/src/Bridge/Azure/Meta/LlamaHandler.php
@@ -41,7 +41,7 @@ final readonly class LlamaHandler implements ModelClient, ResponseConverter
                 'Authorization' => $this->apiKey,
             ],
             'json' => array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'messages' => $input,
             ]),
         ]);

--- a/src/Bridge/Azure/OpenAI/EmbeddingsModelClient.php
+++ b/src/Bridge/Azure/OpenAI/EmbeddingsModelClient.php
@@ -46,7 +46,7 @@ final readonly class EmbeddingsModelClient implements ModelClient
             ],
             'query' => ['api-version' => $this->apiVersion],
             'json' => array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'input' => $input,
             ]),
         ]);

--- a/src/Bridge/Azure/OpenAI/GPTModelClient.php
+++ b/src/Bridge/Azure/OpenAI/GPTModelClient.php
@@ -46,7 +46,7 @@ final readonly class GPTModelClient implements ModelClient
             ],
             'query' => ['api-version' => $this->apiVersion],
             'json' => array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'messages' => $input,
             ]),
         ]);

--- a/src/Bridge/Azure/OpenAI/WhisperModelClient.php
+++ b/src/Bridge/Azure/OpenAI/WhisperModelClient.php
@@ -50,7 +50,7 @@ final readonly class WhisperModelClient implements ModelClient
             ],
             'query' => ['api-version' => $this->apiVersion],
             'body' => array_merge($options, $model->getOptions(), [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'file' => fopen($input->path, 'r'),
             ]),
         ]);

--- a/src/Bridge/Google/Gemini.php
+++ b/src/Bridge/Google/Gemini.php
@@ -18,14 +18,14 @@ final readonly class Gemini implements LanguageModel
      * @param array<string, mixed> $options The default options for the model usage
      */
     public function __construct(
-        private string $version = self::GEMINI_2_PRO,
+        private string $name = self::GEMINI_2_PRO,
         private array $options = ['temperature' => 1.0],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/Google/ModelHandler.php
+++ b/src/Bridge/Google/ModelHandler.php
@@ -48,7 +48,7 @@ final readonly class ModelHandler implements ModelClient, ResponseConverter
 
         $url = sprintf(
             'https://generativelanguage.googleapis.com/v1beta/models/%s:%s',
-            $model->getVersion(),
+            $model->getName(),
             $options['stream'] ?? false ? 'streamGenerateContent' : 'generateContent',
         );
 

--- a/src/Bridge/Meta/Llama.php
+++ b/src/Bridge/Meta/Llama.php
@@ -8,34 +8,34 @@ use PhpLlm\LlmChain\Model\LanguageModel;
 
 final readonly class Llama implements LanguageModel
 {
-    public const LLAMA_3_3_70B_INSTRUCT = 'llama-3.3-70B-Instruct';
-    public const LLAMA_3_2_90B_VISION_INSTRUCT = 'llama-3.2-90b-vision-instruct';
-    public const LLAMA_3_2_11B_VISION_INSTRUCT = 'llama-3.2-11b-vision-instruct';
-    public const LLAMA_3_2_3B = 'llama-3.2-3b';
-    public const LLAMA_3_2_3B_INSTRUCT = 'llama-3.2-3b-instruct';
-    public const LLAMA_3_2_1B = 'llama-3.2-1b';
-    public const LLAMA_3_2_1B_INSTRUCT = 'llama-3.2-1b-instruct';
-    public const LLAMA_3_1_405B_INSTRUCT = 'llama-3.1-405b-instruct';
-    public const LLAMA_3_1_70B = 'llama-3.1-70b';
-    public const LLAMA_3_1_70B_INSTRUCT = 'llama-3-70b-instruct';
-    public const LLAMA_3_1_8B = 'llama-3.1-8b';
-    public const LLAMA_3_1_8B_INSTRUCT = 'llama-3.1-8b-instruct';
-    public const LLAMA_3_70B = 'llama-3-70b';
-    public const LLAMA_3_8B_INSTRUCT = 'llama-3-8b-instruct';
-    public const LLAMA_3_8B = 'llama-3-8b';
+    public const V3_3_70B_INSTRUCT = 'llama-3.3-70B-Instruct';
+    public const V3_2_90B_VISION_INSTRUCT = 'llama-3.2-90b-vision-instruct';
+    public const V3_2_11B_VISION_INSTRUCT = 'llama-3.2-11b-vision-instruct';
+    public const V3_2_3B = 'llama-3.2-3b';
+    public const V3_2_3B_INSTRUCT = 'llama-3.2-3b-instruct';
+    public const V3_2_1B = 'llama-3.2-1b';
+    public const V3_2_1B_INSTRUCT = 'llama-3.2-1b-instruct';
+    public const V3_1_405B_INSTRUCT = 'llama-3.1-405b-instruct';
+    public const V3_1_70B = 'llama-3.1-70b';
+    public const V3_1_70B_INSTRUCT = 'llama-3-70b-instruct';
+    public const V3_1_8B = 'llama-3.1-8b';
+    public const V3_1_8B_INSTRUCT = 'llama-3.1-8b-instruct';
+    public const V3_70B = 'llama-3-70b';
+    public const V3_8B_INSTRUCT = 'llama-3-8b-instruct';
+    public const V3_8B = 'llama-3-8b';
 
     /**
      * @param array<string, mixed> $options
      */
     public function __construct(
-        private string $version = self::LLAMA_3_1_405B_INSTRUCT,
+        private string $name = self::V3_1_405B_INSTRUCT,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/Ollama/LlamaModelHandler.php
+++ b/src/Bridge/Ollama/LlamaModelHandler.php
@@ -33,7 +33,7 @@ final readonly class LlamaModelHandler implements ModelClient, ResponseConverter
         return $this->httpClient->request('POST', sprintf('%s/api/chat', $this->hostUrl), [
             'headers' => ['Content-Type' => 'application/json'],
             'json' => [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'messages' => $input,
                 'stream' => false,
             ],

--- a/src/Bridge/OpenAI/DallE.php
+++ b/src/Bridge/OpenAI/DallE.php
@@ -13,14 +13,14 @@ final readonly class DallE implements Model
 
     /** @param array<string, mixed> $options The default options for the model usage */
     public function __construct(
-        private string $version = self::DALL_E_2,
+        private string $name = self::DALL_E_2,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     /** @return array<string, mixed> */

--- a/src/Bridge/OpenAI/DallE/ModelClient.php
+++ b/src/Bridge/OpenAI/DallE/ModelClient.php
@@ -37,7 +37,7 @@ final readonly class ModelClient implements PlatformResponseFactory, PlatformRes
         return $this->httpClient->request('POST', 'https://api.openai.com/v1/images/generations', [
             'auth_bearer' => $this->apiKey,
             'json' => \array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'prompt' => $input,
             ]),
         ]);

--- a/src/Bridge/OpenAI/Embeddings.php
+++ b/src/Bridge/OpenAI/Embeddings.php
@@ -16,14 +16,14 @@ final readonly class Embeddings implements EmbeddingsModel
      * @param array<string, mixed> $options
      */
     public function __construct(
-        private string $version = self::TEXT_3_SMALL,
+        private string $name = self::TEXT_3_SMALL,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/OpenAI/Embeddings/ModelClient.php
+++ b/src/Bridge/OpenAI/Embeddings/ModelClient.php
@@ -32,7 +32,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $this->httpClient->request('POST', 'https://api.openai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($model->getOptions(), $options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'input' => $input,
             ]),
         ]);

--- a/src/Bridge/OpenAI/GPT.php
+++ b/src/Bridge/OpenAI/GPT.php
@@ -25,28 +25,28 @@ final class GPT implements LanguageModel
      * @param array<mixed> $options The default options for the model usage
      */
     public function __construct(
-        private readonly string $version = self::GPT_4O,
+        private readonly string $name = self::GPT_4O,
         private readonly array $options = ['temperature' => 1.0],
         private bool $supportsAudioInput = false,
         private bool $supportsImageInput = false,
         private bool $supportsStructuredOutput = false,
     ) {
         if (false === $this->supportsAudioInput) {
-            $this->supportsAudioInput = self::GPT_4O_AUDIO === $this->version;
+            $this->supportsAudioInput = self::GPT_4O_AUDIO === $this->name;
         }
 
         if (false === $this->supportsImageInput) {
-            $this->supportsImageInput = in_array($this->version, [self::GPT_4_TURBO, self::GPT_4O, self::GPT_4O_MINI, self::O1_MINI, self::O1_PREVIEW, self::O3_MINI, self::GPT_45_PREVIEW], true);
+            $this->supportsImageInput = in_array($this->name, [self::GPT_4_TURBO, self::GPT_4O, self::GPT_4O_MINI, self::O1_MINI, self::O1_PREVIEW, self::O3_MINI, self::GPT_45_PREVIEW], true);
         }
 
         if (false === $this->supportsStructuredOutput) {
-            $this->supportsStructuredOutput = in_array($this->version, [self::GPT_4O, self::GPT_4O_MINI, self::O3_MINI, self::GPT_45_PREVIEW], true);
+            $this->supportsStructuredOutput = in_array($this->name, [self::GPT_4O, self::GPT_4O_MINI, self::O3_MINI, self::GPT_45_PREVIEW], true);
         }
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/OpenAI/GPT/ModelClient.php
+++ b/src/Bridge/OpenAI/GPT/ModelClient.php
@@ -35,7 +35,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $this->httpClient->request('POST', 'https://api.openai.com/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'messages' => $input,
             ]),
         ]);

--- a/src/Bridge/OpenAI/Whisper.php
+++ b/src/Bridge/OpenAI/Whisper.php
@@ -14,14 +14,14 @@ final readonly class Whisper implements Model
      * @param array<string, mixed> $options
      */
     public function __construct(
-        private string $version = self::WHISPER_1,
+        private string $name = self::WHISPER_1,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/OpenAI/Whisper/ModelClient.php
+++ b/src/Bridge/OpenAI/Whisper/ModelClient.php
@@ -34,7 +34,7 @@ final readonly class ModelClient implements BaseModelClient
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'multipart/form-data'],
             'body' => array_merge($options, $model->getOptions(), [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'file' => fopen($input->path, 'r'),
             ]),
         ]);

--- a/src/Bridge/OpenRouter/Client.php
+++ b/src/Bridge/OpenRouter/Client.php
@@ -39,7 +39,7 @@ final readonly class Client implements ModelClient, ResponseConverter
         return $this->httpClient->request('POST', 'https://openrouter.ai/api/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'messages' => $input,
             ]),
         ]);

--- a/src/Bridge/OpenRouter/GenericModel.php
+++ b/src/Bridge/OpenRouter/GenericModel.php
@@ -13,14 +13,14 @@ final readonly class GenericModel implements LanguageModel
      * @param array<string, mixed> $options
      */
     public function __construct(
-        private string $version = Llama::LLAMA_3_2_90B_VISION_INSTRUCT,
+        private string $name = Llama::V3_2_90B_VISION_INSTRUCT,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Bridge/Replicate/LlamaModelClient.php
+++ b/src/Bridge/Replicate/LlamaModelClient.php
@@ -31,7 +31,7 @@ final readonly class LlamaModelClient implements ModelClient
         Assert::isInstanceOf($model, Llama::class);
         Assert::isInstanceOf($input, MessageBagInterface::class);
 
-        return $this->client->request(sprintf('meta/meta-%s', $model->getVersion()), 'predictions', [
+        return $this->client->request(sprintf('meta/meta-%s', $model->getName()), 'predictions', [
             'system' => $this->promptConverter->convertMessage($input->getSystemMessage() ?? new SystemMessage('')),
             'prompt' => $this->promptConverter->convertToPrompt($input->withoutSystemMessage()),
         ]);

--- a/src/Bridge/Voyage/ModelHandler.php
+++ b/src/Bridge/Voyage/ModelHandler.php
@@ -32,7 +32,7 @@ final readonly class ModelHandler implements ModelClient, ResponseConverter
         return $this->httpClient->request('POST', 'https://api.voyageai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'json' => [
-                'model' => $model->getVersion(),
+                'model' => $model->getName(),
                 'input' => $input,
             ],
         ]);

--- a/src/Bridge/Voyage/Voyage.php
+++ b/src/Bridge/Voyage/Voyage.php
@@ -8,25 +8,25 @@ use PhpLlm\LlmChain\Model\EmbeddingsModel;
 
 final readonly class Voyage implements EmbeddingsModel
 {
-    public const VERSION_V3 = 'voyage-3';
-    public const VERSION_V3_LITE = 'voyage-3-lite';
-    public const VERSION_FINANCE_2 = 'voyage-finance-2';
-    public const VERSION_MULTILINGUAL_2 = 'voyage-multilingual-2';
-    public const VERSION_LAW_2 = 'voyage-law-2';
-    public const VERSION_CODE_2 = 'voyage-code-2';
+    public const V3 = 'voyage-3';
+    public const V3_LITE = 'voyage-3-lite';
+    public const FINANCE_2 = 'voyage-finance-2';
+    public const MULTILINGUAL_2 = 'voyage-multilingual-2';
+    public const LAW_2 = 'voyage-law-2';
+    public const CODE_2 = 'voyage-code-2';
 
     /**
      * @param array<string, mixed> $options
      */
     public function __construct(
-        private string $version = self::VERSION_V3,
+        private string $name = self::V3,
         private array $options = [],
     ) {
     }
 
-    public function getVersion(): string
+    public function getName(): string
     {
-        return $this->version;
+        return $this->name;
     }
 
     public function getOptions(): array

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -6,7 +6,7 @@ namespace PhpLlm\LlmChain\Model;
 
 interface Model
 {
-    public function getVersion(): string;
+    public function getName(): string;
 
     /**
      * @return array<string, mixed>

--- a/tests/Bridge/OpenAI/DallETest.php
+++ b/tests/Bridge/OpenAI/DallETest.php
@@ -19,7 +19,7 @@ final class DallETest extends TestCase
     {
         $dallE = new DallE();
 
-        self::assertSame(DallE::DALL_E_2, $dallE->getVersion());
+        self::assertSame(DallE::DALL_E_2, $dallE->getName());
         self::assertSame([], $dallE->getOptions());
     }
 
@@ -28,7 +28,7 @@ final class DallETest extends TestCase
     {
         $dallE = new DallE(DallE::DALL_E_3, ['response_format' => 'base64', 'n' => 2]);
 
-        self::assertSame(DallE::DALL_E_3, $dallE->getVersion());
+        self::assertSame(DallE::DALL_E_3, $dallE->getName());
         self::assertSame(['response_format' => 'base64', 'n' => 2], $dallE->getOptions());
     }
 }


### PR DESCRIPTION
I'm currently working on an integration for Hugging Face and I think `$version` is misleading since this could also use quite different Models of one family.

Looking more into the direction of `GenericModel` what we saw already with #203 
https://github.com/php-llm/llm-chain/blob/main/src/Bridge/OpenRouter/GenericModel.php

WDYT @OskarStark @DZunke 