### PR TITLE
feat: add support for Hugging Face Inference API

### DIFF
--- a/.env
+++ b/.env
@@ -25,6 +25,9 @@ AZURE_OPENAI_KEY=
 AZURE_LLAMA_BASEURL=
 AZURE_LLAMA_KEY=
 
+# Hugging Face Access Token
+HUGGINGFACE_KEY=
+
 # For using OpenRouter
 OPENROUTER_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ coverage:
 
 run-examples:
 	./example
+	./huggingface
+
+make huggingface-models:
+	php examples/huggingface/_model-listing.php
 
 ci: ci-stable
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # LLM Chain
 
-PHP library for building LLM-based features and applications.
+PHP library for building LLM-based and AI-based features and applications.
 
-This library is not a stable yet, but still rather experimental. Feel free to try it out, give feedback, ask questions, contribute or share your use cases.
-Abstractions, concepts and interfaces are not final and potentially subject of change.
+This library is not a stable yet, but still rather experimental. Feel free to try it out, give feedback, ask questions,
+contribute or share your use cases. Abstractions, concepts and interfaces are not final and potentially subject of change.
 
 ## Requirements
 
@@ -25,7 +25,7 @@ See [examples](examples) folder to run example implementations using this librar
 Depending on the example you need to export different environment variables
 for API keys or deployment configurations or create a `.env.local` based on `.env` file.
 
-To run all examples, use `make run-examples` or `php example`.
+To run all examples, use `make run-examples` or `php example` and `php huggingface` for all HuggingFace related examples.
 
 For a more sophisticated demo, see the [Symfony Demo Application](https://github.com/php-llm/symfony-demo).
 
@@ -33,7 +33,8 @@ For a more sophisticated demo, see the [Symfony Demo Application](https://github
 
 ### Models & Platforms
 
-LLM Chain categorizes two main types of models: **Language Models** and **Embeddings Models**.
+LLM Chain categorizes two main types of models: **Language Models** and **Embeddings Models**. On top of that, there are
+other models, like text-to-speech, image generation or classification models that are also supported.
 
 Language Models, like GPT, Claude and Llama, as essential centerpiece of LLM applications
 and Embeddings Models as supporting models to provide vector representations of text.
@@ -71,6 +72,8 @@ $embeddings = new Embeddings();
 * Other Models
   * [OpenAI's Dall·E](https://platform.openai.com/docs/guides/image-generation) with [OpenAI](https://platform.openai.com/docs/overview) as Platform
   * [OpenAI's Whisper](https://platform.openai.com/docs/guides/speech-to-text) with [OpenAI](https://platform.openai.com/docs/overview) and [Azure](https://learn.microsoft.com/azure/ai-services/openai/concepts/models) as Platform
+  * All models provided by [HuggingFace](https://huggingface.co/) can be listed with `make huggingface-models`
+    And more filtered with `php examples/huggingface/_model-listing.php --provider=hf-inference --task=object-detection`
 
 See [issue #28](https://github.com/php-llm/llm-chain/issues/28) for planned support of other models and platforms.
 
@@ -724,6 +727,51 @@ final class MyProcessor implements OutputProcessor, ChainAwareProcessor
     }
 }
 ```
+
+## HuggingFace
+
+LLM Chain comes out of the box with an integration for [HuggingFace](https://huggingface.co/)  which is a platform for
+hosting and sharing all kind of models, including LLMs, embeddings, image generation and classification models.
+
+You can just instantiate the Platform with the corresponding HuggingFace bridge and use it with the `task` option:
+```php
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+
+$platform = PlatformFactory::create($apiKey);
+$model = new Model('facebook/detr-resnet-50');
+
+$image = Image::fromFile(dirname(__DIR__, 2).'/tests/Fixture/image.jpg');
+$response = $platform->request($model, $image, [
+    'task' => Task::OBJECT_DETECTION, // defining a task is mandatory for internal request & response handling
+]);
+
+dump($response->getContent());
+```
+
+#### Code Examples
+
+1. [Audio Classification](examples/huggingface/audio-classification.php)
+1. [Automatic Speech Recognition](examples/huggingface/automatic-speech-recognition.php)
+1. [Chat Completion](examples/huggingface/chat-completion.php)
+1. [Feature Extraction (Embeddings)](examples/huggingface/feature-extraction.php)
+1. [Fill Mask](examples/huggingface/fill-mask.php)
+1. [Image Classification](examples/huggingface/image-classification.php)
+1. [Image Segmentation.php](examples/huggingface/image-segmentation.php)
+1. [Image-to-Text](examples/huggingface/image-to-text.php)
+1. [Object Detection](examples/huggingface/object-detection.php)
+1. [Question Answering](examples/huggingface/question-answering.php)
+1. [Sentence Similarity](examples/huggingface/sentence-similarity.php)
+1. [Summarization](examples/huggingface/summarization.php)
+1. [Table Question Answering](examples/huggingface/table-question-answering.php)
+1. [Text Classification](examples/huggingface/text-classification.php)
+1. [Text Generation](examples/huggingface/text-generation.php)
+1. [Text-to-Image](examples/huggingface/text-to-image.php)
+1. [Token Classification](examples/huggingface/token-classification.php)
+1. [Translation](examples/huggingface/translation.php)
+1. [Zero-shot Classification](examples/huggingface/zero-shot-classification.php)
 
 ## Contributions
 

--- a/examples/huggingface/_model-listing.php
+++ b/examples/huggingface/_model-listing.php
@@ -1,0 +1,39 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\ApiClient;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+
+$app = (new SingleCommandApplication('HuggingFace Model Listing'))
+    ->setDescription('Lists all available models on HuggingFace')
+    ->addOption('provider', 'p', InputOption::VALUE_REQUIRED, 'Name of the inference provider to filter models by')
+    ->addOption('task', 't', InputOption::VALUE_REQUIRED, 'Name of the task to filter models by')
+    ->setCode(function (InputInterface $input, ConsoleOutput $output) {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('HuggingFace Model Listing');
+
+        $provider = $input->getOption('provider');
+        $task = $input->getOption('task');
+
+        $models = (new ApiClient())->models($provider, $task);
+
+        if (0 === count($models)) {
+            $io->error('No models found for the given provider and task.');
+
+            return Command::FAILURE;
+        }
+
+        $io->listing(
+            array_map(fn (Model $model) => $model->getName(), $models)
+        );
+
+        return Command::SUCCESS;
+    })
+    ->run();

--- a/examples/huggingface/audio-classification.php
+++ b/examples/huggingface/audio-classification.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Audio;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('MIT/ast-finetuned-audioset-10-10-0.4593');
+$audio = Audio::fromFile(dirname(__DIR__, 2).'/tests/Fixture/audio.mp3');
+
+$response = $platform->request($model, $audio, [
+    'task' => Task::AUDIO_CLASSIFICATION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/automatic-speech-recognition.php
+++ b/examples/huggingface/automatic-speech-recognition.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Audio;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('openai/whisper-large-v3');
+$audio = Audio::fromFile(dirname(__DIR__, 2).'/tests/Fixture/audio.mp3');
+
+$response = $platform->request($model, $audio, [
+    'task' => Task::AUTOMATIC_SPEECH_RECOGNITION,
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/chat-completion.php
+++ b/examples/huggingface/chat-completion.php
@@ -1,0 +1,26 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Message;
+use PhpLlm\LlmChain\Model\Message\MessageBag;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('HuggingFaceH4/zephyr-7b-beta');
+
+$messages = new MessageBag(Message::ofUser('Hello, how are you doing today?'));
+$response = $platform->request($model, $messages, [
+    'task' => Task::CHAT_COMPLETION,
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/feature-extraction.php
+++ b/examples/huggingface/feature-extraction.php
@@ -1,0 +1,26 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Response\VectorResponse;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('thenlper/gte-large');
+
+$response = $platform->request($model, 'Today is a sunny day and I will get some ice cream.', [
+    'task' => Task::FEATURE_EXTRACTION,
+]);
+
+assert($response instanceof VectorResponse);
+
+echo 'Dimensions: '.$response->getContent()[0]->getDimensions().PHP_EOL;

--- a/examples/huggingface/fill-mask.php
+++ b/examples/huggingface/fill-mask.php
@@ -1,0 +1,23 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('FacebookAI/xlm-roberta-base');
+
+$response = $platform->request($model, 'Hello I\'m a <mask> model.', [
+    'task' => Task::FILL_MASK,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/image-classification.php
+++ b/examples/huggingface/image-classification.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('google/vit-base-patch16-224');
+
+$image = Image::fromFile(dirname(__DIR__, 2).'/tests/Fixture/image.jpg');
+$response = $platform->request($model, $image, [
+    'task' => Task::IMAGE_CLASSIFICATION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/image-segmentation.php
+++ b/examples/huggingface/image-segmentation.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('nvidia/segformer-b0-finetuned-ade-512-512');
+
+$image = Image::fromFile(dirname(__DIR__, 2).'/tests/Fixture/image.jpg');
+$response = $platform->request($model, $image, [
+    'task' => Task::IMAGE_SEGMENTATION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/image-to-text.php
+++ b/examples/huggingface/image-to-text.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('Salesforce/blip-image-captioning-base');
+
+$image = Image::fromFile(dirname(__DIR__, 2).'/tests/Fixture/image.jpg');
+$response = $platform->request($model, $image, [
+    'task' => Task::IMAGE_TO_TEXT,
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/object-detection.php
+++ b/examples/huggingface/object-detection.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('facebook/detr-resnet-50');
+
+$image = Image::fromFile(dirname(__DIR__, 2).'/tests/Fixture/image.jpg');
+$response = $platform->request($model, $image, [
+    'task' => Task::OBJECT_DETECTION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/question-answering.php
+++ b/examples/huggingface/question-answering.php
@@ -1,0 +1,28 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('deepset/roberta-base-squad2');
+
+$input = [
+    'question' => 'What is the capital of France?',
+    'context' => 'Paris is the capital and most populous city of France, with an estimated population of 2,175,601 residents as of 2018, in an area of more than 105 square kilometres.',
+];
+
+$response = $platform->request($model, $input, [
+    'task' => Task::QUESTION_ANSWERING,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/sentence-similarity.php
+++ b/examples/huggingface/sentence-similarity.php
@@ -1,0 +1,32 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('sentence-transformers/all-MiniLM-L6-v2');
+
+$input = [
+    'source_sentence' => 'That is a happy dog',
+    'sentences' => [
+        'That is a happy canine',
+        'That is a happy cat',
+        'Today is a sunny day',
+    ],
+];
+
+$response = $platform->request($model, $input, [
+    'task' => Task::SENTENCE_SIMILARITY,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/summarization.php
+++ b/examples/huggingface/summarization.php
@@ -1,0 +1,33 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('facebook/bart-large-cnn');
+
+$longText = <<<TEXT
+    The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure
+    in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower
+    surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41
+    years until the Chrysler Building in New York City was finished in 1930. It was the first structure to reach a
+    height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller
+    than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second tallest
+    free-standing structure in France after the Millau Viaduct.
+    TEXT;
+
+$response = $platform->request($model, $longText, [
+    'task' => Task::SUMMARIZATION,
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/table-question-answering.php
+++ b/examples/huggingface/table-question-answering.php
@@ -1,0 +1,31 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('microsoft/tapex-base');
+
+$input = [
+    'query' => 'select year where city = beijing',
+    'table' => [
+        'year' => [1896, 1900, 1904, 2004, 2008, 2012],
+        'city' => ['athens', 'paris', 'st. louis', 'athens', 'beijing', 'london'],
+    ],
+];
+
+$response = $platform->request($model, $input, [
+    'task' => Task::TABLE_QUESTION_ANSWERING,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/text-classification.php
+++ b/examples/huggingface/text-classification.php
@@ -1,0 +1,23 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('ProsusAI/finbert');
+
+$response = $platform->request($model, 'I like you. I love you.', [
+    'task' => Task::TEXT_CLASSIFICATION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/text-generation.php
+++ b/examples/huggingface/text-generation.php
@@ -1,0 +1,23 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('gpt2');
+
+$response = $platform->request($model, 'The quick brown fox jumps over the lazy', [
+    'task' => Task::TEXT_GENERATION,
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -1,0 +1,26 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Response\BinaryResponse;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('black-forest-labs/FLUX.1-dev');
+
+$response = $platform->request($model, 'Astronaut riding a horse', [
+    'task' => Task::TEXT_TO_IMAGE,
+]);
+
+assert($response instanceof BinaryResponse);
+
+echo $response->toBase64().PHP_EOL;

--- a/examples/huggingface/token-classification.php
+++ b/examples/huggingface/token-classification.php
@@ -1,0 +1,23 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('dbmdz/bert-large-cased-finetuned-conll03-english');
+
+$response = $platform->request($model, 'John Smith works at Microsoft in London.', [
+    'task' => Task::TOKEN_CLASSIFICATION,
+]);
+
+dump($response->getContent());

--- a/examples/huggingface/translation.php
+++ b/examples/huggingface/translation.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('facebook/mbart-large-50-many-to-many-mmt');
+
+$response = $platform->request($model, 'Меня зовут Вольфганг и я живу в Берлине', [
+    'task' => Task::TRANSLATION,
+    'src_lang' => 'ru',
+    'tgt_lang' => 'en',
+]);
+
+echo $response->getContent().PHP_EOL;

--- a/examples/huggingface/zero-shot-classification.php
+++ b/examples/huggingface/zero-shot-classification.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\PlatformFactory;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
+
+if (empty($_ENV['HUGGINGFACE_KEY'])) {
+    echo 'Please set the HUGGINGFACE_KEY environment variable.'.PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['HUGGINGFACE_KEY']);
+$model = new Model('facebook/bart-large-mnli');
+
+$text = 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!';
+$response = $platform->request($model, $text, [
+    'task' => Task::ZERO_SHOT_CLASSIFICATION,
+    'candidate_labels' => ['refund', 'legal', 'faq'],
+]);
+
+dump($response->getContent());

--- a/huggingface
+++ b/huggingface
@@ -1,0 +1,102 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Process\Process;
+
+require_once __DIR__.'/vendor/autoload.php';
+
+$app = (new SingleCommandApplication('HuggingFace Example Runner'))
+    ->setDescription('Runs all HuggingFace examples in folder examples/huggingface/')
+    ->setCode(function (InputInterface $input, ConsoleOutput $output) {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('HuggingFace Examples');
+
+        $examples = (new Finder())
+            ->in(__DIR__.'/examples/huggingface')
+            ->name('*.php')
+            ->sortByName()
+            ->files();
+
+        /** @var array{example: SplFileInfo, process: Process} $exampleRuns */
+        $exampleRuns = [];
+        foreach ($examples as $example) {
+            $exampleRuns[] = [
+                'example' => $example,
+                'process' => $process = new Process(['php', $example->getRealPath()]),
+            ];
+            $process->start();
+        }
+
+        $examplesRunning = fn () => array_reduce($exampleRuns, fn ($running, $example) => $running || $example['process']->isRunning(), false);
+        $examplesSuccessful = fn () => array_reduce($exampleRuns, fn ($successful, $example) => $successful && $example['process']->isSuccessful(), true);
+
+        $section = $output->section();
+        $renderTable = function () use ($exampleRuns, $section) {
+            $section->clear();
+            $table = new Table($section);
+            $table->setHeaders(['Example', 'State', 'Output']);
+            foreach ($exampleRuns as $run) {
+                /** @var SplFileInfo $example */
+                /** @var Process $process */
+                ['example' => $example, 'process' => $process] = $run;
+
+                $output = str_replace(PHP_EOL, ' ', $process->getOutput());
+                $output = strlen($output) <= 100 ? $output : substr($output, 0, 100).'...';
+                $emptyOutput = 0 === strlen(trim($output));
+
+                $state = 'Running';
+                if ($process->isTerminated()) {
+                    $success = $process->isSuccessful() && !$emptyOutput;
+                    $state = $success ? '<info>Finished</info>'
+                        : (1 === $run['process']->getExitCode() || $emptyOutput ? '<error>Failed</error>' : '<comment>Skipped</comment>');
+                }
+
+                $table->addRow([$example->getFilename(), $state, $output]);
+            }
+            $table->render();
+        };
+
+        while ($examplesRunning()) {
+            $renderTable();
+            sleep(1);
+        }
+
+        $renderTable();
+
+        $io->newLine();
+        
+        // Count successful examples
+        $successCount = array_reduce($exampleRuns, function ($count, $example) {
+            if ($example['process']->isSuccessful() && strlen(trim($example['process']->getOutput())) > 0) {
+                return $count + 1;
+            }
+            return $count;
+        }, 0);
+        
+        $totalCount = count($exampleRuns);
+        
+        if ($successCount < $totalCount) {
+            $io->warning("$successCount out of $totalCount examples ran successfully. Some examples may have failed due to API limits or unavailable models.");
+        } else {
+            $io->success("All $totalCount examples ran successfully!");
+        }
+
+        // Display detailed error information for failed examples
+        foreach ($exampleRuns as $run) {
+            if (!$run['process']->isSuccessful()) {
+                $io->section('Error in ' . $run['example']->getFilename());
+                $io->text($run['process']->getErrorOutput());
+            }
+        }
+
+        return Command::SUCCESS;
+    })
+    ->run();

--- a/src/Bridge/HuggingFace/ApiClient.php
+++ b/src/Bridge/HuggingFace/ApiClient.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class ApiClient
+{
+    public function __construct(
+        private ?HttpClientInterface $httpClient = null,
+    ) {
+        $this->httpClient = $httpClient ?? HttpClient::create();
+    }
+
+    /**
+     * @return Model[]
+     */
+    public function models(?string $provider, ?string $task): array
+    {
+        $response = $this->httpClient->request('GET', 'https://huggingface.co/api/models', [
+            'query' => [
+                'inference_provider' => $provider,
+                'pipeline_tag' => $task,
+            ],
+        ]);
+
+        return array_map(fn (array $model) => new Model($model['id']), $response->toArray());
+    }
+}

--- a/src/Bridge/HuggingFace/Model.php
+++ b/src/Bridge/HuggingFace/Model.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+use PhpLlm\LlmChain\Model\Model as BaseModel;
+
+final readonly class Model implements BaseModel
+{
+    /**
+     * @param string               $name    the name of the model is optional with HuggingFace
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        private ?string $name = null,
+        private array $options = [],
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name ?? '';
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/Bridge/HuggingFace/ModelClient.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+use PhpLlm\LlmChain\Model\Message\Content\Audio;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use PhpLlm\LlmChain\Model\Message\MessageBagInterface;
+use PhpLlm\LlmChain\Model\Model as BaseModel;
+use PhpLlm\LlmChain\Platform\ModelClient as PlatformModelClient;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class ModelClient implements PlatformModelClient
+{
+    private EventSourceHttpClient $httpClient;
+
+    public function __construct(
+        HttpClientInterface $httpClient,
+        private string $provider,
+        #[\SensitiveParameter]
+        private string $apiKey,
+    ) {
+        $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+    }
+
+    public function supports(BaseModel $model, object|array|string $input): bool
+    {
+        return $model instanceof Model;
+    }
+
+    public function request(BaseModel $model, object|array|string $input, array $options = []): ResponseInterface
+    {
+        Assert::isInstanceOf($model, Model::class);
+        $task = $options['task'] ?? null;
+        unset($options['task']);
+
+        return $this->httpClient->request('POST', $this->getUrl($model, $input, $task), [
+            'auth_bearer' => $this->apiKey,
+            ...$this->getPayload($input, $options),
+        ]);
+    }
+
+    /**
+     * @param array<mixed>|string|object $input
+     */
+    private function getUrl(Model $model, object|array|string $input, ?string $task): string
+    {
+        $endpoint = Task::FEATURE_EXTRACTION === $task ? 'pipeline/feature-extraction' : 'models';
+        $url = sprintf('https://router.huggingface.co/%s/%s/%s', $this->provider, $endpoint, $model->getName());
+
+        if ($input instanceof MessageBagInterface) {
+            $url .= '/v1/chat/completions';
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param array<mixed>|string|object $input
+     * @param array<string, mixed>       $options
+     *
+     * @return array<string, mixed>
+     */
+    private function getPayload(object|array|string $input, array $options): array
+    {
+        if ($input instanceof Audio || $input instanceof Image) {
+            return [
+                'headers' => ['Content-Type' => $input->getFormat()],
+                'body' => $input->asBinary(),
+            ];
+        }
+
+        if ($input instanceof MessageBagInterface) {
+            return [
+                'headers' => ['Content-Type' => 'application/json'],
+                'json' => [
+                    'messages' => $input,
+                    ...$options,
+                ],
+            ];
+        }
+
+        if (is_string($input) || is_array($input)) {
+            $payload = [
+                'headers' => ['Content-Type' => 'application/json'],
+                'json' => [
+                    'inputs' => $input,
+                ],
+            ];
+
+            if (0 !== count($options)) {
+                $payload['json']['parameters'] = $options;
+            }
+
+            return $payload;
+        }
+
+        throw new \InvalidArgumentException('Unsupported input type: '.get_debug_type($input));
+    }
+}

--- a/src/Bridge/HuggingFace/Output/Classification.php
+++ b/src/Bridge/HuggingFace/Output/Classification.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class Classification
+{
+    public function __construct(
+        public string $label,
+        public float $score,
+    ) {
+    }
+}

--- a/src/Bridge/HuggingFace/Output/ClassificationResult.php
+++ b/src/Bridge/HuggingFace/Output/ClassificationResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class ClassificationResult
+{
+    /**
+     * @param Classification[] $classifications
+     */
+    public function __construct(
+        public array $classifications,
+    ) {
+    }
+
+    /**
+     * @param array<array{label: string, score: float}> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_map(fn (array $item) => new Classification($item['label'], $item['score']), $data)
+        );
+    }
+}

--- a/src/Bridge/HuggingFace/Output/DetectedObject.php
+++ b/src/Bridge/HuggingFace/Output/DetectedObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class DetectedObject
+{
+    public function __construct(
+        public string $label,
+        public float $score,
+        public float $xmin,
+        public float $ymin,
+        public float $xmax,
+        public float $ymax,
+    ) {
+    }
+}

--- a/src/Bridge/HuggingFace/Output/FillMaskResult.php
+++ b/src/Bridge/HuggingFace/Output/FillMaskResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class FillMaskResult
+{
+    /**
+     * @param MaskFill[] $fills
+     */
+    public function __construct(
+        public array $fills,
+    ) {
+    }
+
+    /**
+     * @param array<array{token: int, token_str: string, sequence: string, score: float}> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(
+            fn (array $item) => new MaskFill(
+                $item['token'],
+                $item['token_str'],
+                $item['sequence'],
+                $item['score'],
+            ),
+            $data,
+        ));
+    }
+}

--- a/src/Bridge/HuggingFace/Output/ImageSegment.php
+++ b/src/Bridge/HuggingFace/Output/ImageSegment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class ImageSegment
+{
+    public function __construct(
+        public string $label,
+        public float $score,
+        public string $mask,
+    ) {
+    }
+}

--- a/src/Bridge/HuggingFace/Output/ImageSegmentationResult.php
+++ b/src/Bridge/HuggingFace/Output/ImageSegmentationResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class ImageSegmentationResult
+{
+    /**
+     * @param ImageSegment[] $segments
+     */
+    public function __construct(
+        public array $segments,
+    ) {
+    }
+
+    /**
+     * @param array<array{label: string, score: float, mask: string}> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_map(fn (array $item) => new ImageSegment($item['label'], $item['score'], $item['mask']), $data)
+        );
+    }
+}

--- a/src/Bridge/HuggingFace/Output/MaskFill.php
+++ b/src/Bridge/HuggingFace/Output/MaskFill.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class MaskFill
+{
+    public function __construct(
+        public int $token,
+        public string $tokenStr,
+        public string $sequence,
+        public float $score,
+    ) {
+    }
+}

--- a/src/Bridge/HuggingFace/Output/ObjectDetectionResult.php
+++ b/src/Bridge/HuggingFace/Output/ObjectDetectionResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class ObjectDetectionResult
+{
+    /**
+     * @param DetectedObject[] $objects
+     */
+    public function __construct(
+        public array $objects,
+    ) {
+    }
+
+    /**
+     * @param array<array{label: string, score: float, box: array{xmin: float, ymin: float, xmax: float, ymax: float}}> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(
+            fn (array $item) => new DetectedObject(
+                $item['label'],
+                $item['score'],
+                $item['box']['xmin'],
+                $item['box']['ymin'],
+                $item['box']['xmax'],
+                $item['box']['ymax'],
+            ),
+            $data,
+        ));
+    }
+}

--- a/src/Bridge/HuggingFace/Output/QuestionAnsweringResult.php
+++ b/src/Bridge/HuggingFace/Output/QuestionAnsweringResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class QuestionAnsweringResult
+{
+    public function __construct(
+        public string $answer,
+        public int $startIndex,
+        public int $endIndex,
+        public float $score,
+    ) {
+    }
+
+    /**
+     * @param array{answer: string, start: int, end: int, score: float} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['answer'],
+            $data['start'],
+            $data['end'],
+            $data['score'],
+        );
+    }
+}

--- a/src/Bridge/HuggingFace/Output/SentenceSimilarityResult.php
+++ b/src/Bridge/HuggingFace/Output/SentenceSimilarityResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class SentenceSimilarityResult
+{
+    /**
+     * @param array<float> $similarities
+     */
+    public function __construct(
+        public array $similarities,
+    ) {
+    }
+
+    /**
+     * @param array<float> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self($data);
+    }
+}

--- a/src/Bridge/HuggingFace/Output/TableQuestionAnsweringResult.php
+++ b/src/Bridge/HuggingFace/Output/TableQuestionAnsweringResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class TableQuestionAnsweringResult
+{
+    /**
+     * @param array<int, string|int> $cells
+     * @param array<string>          $aggregator
+     */
+    public function __construct(
+        public string $answer,
+        public array $cells = [],
+        public array $aggregator = [],
+    ) {
+    }
+
+    /**
+     * @param array{answer: string, cells?: array<int, string|int>, aggregator?: array<string>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['answer'],
+            $data['cells'] ?? [],
+            $data['aggregator'] ?? [],
+        );
+    }
+}

--- a/src/Bridge/HuggingFace/Output/Token.php
+++ b/src/Bridge/HuggingFace/Output/Token.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final readonly class Token
+{
+    public function __construct(
+        public string $entityGroup,
+        public float $score,
+        public string $word,
+        public int $start,
+        public int $end,
+    ) {
+    }
+}

--- a/src/Bridge/HuggingFace/Output/TokenClassificationResult.php
+++ b/src/Bridge/HuggingFace/Output/TokenClassificationResult.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class TokenClassificationResult
+{
+    /**
+     * @param Token[] $tokens
+     */
+    public function __construct(
+        public array $tokens,
+    ) {
+    }
+
+    /**
+     * @param array<array{entity_group: string, score: float, word: string, start: int, end: int}> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(
+            fn (array $item) => new Token(
+                $item['entity_group'],
+                $item['score'],
+                $item['word'],
+                $item['start'],
+                $item['end'],
+            ),
+            $data,
+        ));
+    }
+}

--- a/src/Bridge/HuggingFace/Output/ZeroShotClassificationResult.php
+++ b/src/Bridge/HuggingFace/Output/ZeroShotClassificationResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace\Output;
+
+final class ZeroShotClassificationResult
+{
+    /**
+     * @param array<string> $labels
+     * @param array<float>  $scores
+     */
+    public function __construct(
+        public array $labels,
+        public array $scores,
+        public ?string $sequence = null,
+    ) {
+    }
+
+    /**
+     * @param array{labels: array<string>, scores: array<float>, sequence?: string} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['labels'],
+            $data['scores'],
+            $data['sequence'] ?? null,
+        );
+    }
+}

--- a/src/Bridge/HuggingFace/PlatformFactory.php
+++ b/src/Bridge/HuggingFace/PlatformFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+use PhpLlm\LlmChain\Platform;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class PlatformFactory
+{
+    public static function create(
+        #[\SensitiveParameter]
+        string $apiKey,
+        string $provider = Provider::HF_INFERENCE,
+        ?HttpClientInterface $httpClient = null,
+    ): Platform {
+        $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+
+        return new Platform([new ModelClient($httpClient, $provider, $apiKey)], [new ResponseConverter()]);
+    }
+}

--- a/src/Bridge/HuggingFace/Provider.php
+++ b/src/Bridge/HuggingFace/Provider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+interface Provider
+{
+    public const CEREBRAS = 'cerebras';
+    public const COHERE = 'cohere';
+    public const FAL_AI = 'fal-ai';
+    public const FIREWORKS = 'fireworks-ai';
+    public const HYPERBOLIC = 'hyperbolic';
+    public const HF_INFERENCE = 'hf-inference';
+    public const NEBIUS = 'nebius';
+    public const NOVITA = 'novita';
+    public const REPLICATE = 'replicate';
+    public const SAMBA_NOVA = 'sambanova';
+    public const TOGETHER = 'together';
+}

--- a/src/Bridge/HuggingFace/ResponseConverter.php
+++ b/src/Bridge/HuggingFace/ResponseConverter.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\ClassificationResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\FillMaskResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\ImageSegmentationResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\ObjectDetectionResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\QuestionAnsweringResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\SentenceSimilarityResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\TableQuestionAnsweringResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\TokenClassificationResult;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Output\ZeroShotClassificationResult;
+use PhpLlm\LlmChain\Document\Vector;
+use PhpLlm\LlmChain\Model\Model as BaseModel;
+use PhpLlm\LlmChain\Model\Response\BinaryResponse;
+use PhpLlm\LlmChain\Model\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Model\Response\StructuredResponse;
+use PhpLlm\LlmChain\Model\Response\TextResponse;
+use PhpLlm\LlmChain\Model\Response\VectorResponse;
+use PhpLlm\LlmChain\Platform\ResponseConverter as PlatformResponseConverter;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final readonly class ResponseConverter implements PlatformResponseConverter
+{
+    public function supports(BaseModel $model, array|string|object $input): bool
+    {
+        return $model instanceof Model;
+    }
+
+    public function convert(ResponseInterface $response, array $options = []): LlmResponse
+    {
+        if (503 === $response->getStatusCode()) {
+            return throw new \RuntimeException('Service unavailable.');
+        }
+
+        if (404 === $response->getStatusCode()) {
+            return throw new \InvalidArgumentException('Model, provider or task not found (404).');
+        }
+
+        $headers = $response->getHeaders(false);
+        $contentType = $headers['content-type'][0] ?? null;
+        $content = 'application/json' === $contentType ? $response->toArray(false) : $response->getContent(false);
+
+        if (str_starts_with((string) $response->getStatusCode(), '4')) {
+            $message = is_string($content) ? $content :
+                (is_array($content['error']) ? $content['error'][0] : $content['error']);
+
+            throw new \InvalidArgumentException(sprintf('API Client Error (%d): %s', $response->getStatusCode(), $message));
+        }
+
+        if (200 !== $response->getStatusCode()) {
+            throw new \RuntimeException('Unhandled response code: '.$response->getStatusCode());
+        }
+
+        $task = $options['task'] ?? null;
+
+        return match ($task) {
+            Task::AUDIO_CLASSIFICATION, Task::IMAGE_CLASSIFICATION => new StructuredResponse(
+                ClassificationResult::fromArray($content)
+            ),
+            Task::AUTOMATIC_SPEECH_RECOGNITION => new TextResponse($content['text'] ?? ''),
+            Task::CHAT_COMPLETION => new TextResponse($content['choices'][0]['message']['content'] ?? ''),
+            Task::FEATURE_EXTRACTION => new VectorResponse(new Vector($content)),
+            Task::TEXT_CLASSIFICATION => new StructuredResponse(ClassificationResult::fromArray(reset($content) ?? [])),
+            Task::FILL_MASK => new StructuredResponse(FillMaskResult::fromArray($content)),
+            Task::IMAGE_SEGMENTATION => new StructuredResponse(ImageSegmentationResult::fromArray($content)),
+            Task::IMAGE_TO_TEXT, Task::TEXT_GENERATION => new TextResponse($content[0]['generated_text'] ?? ''),
+            Task::TEXT_TO_IMAGE => new BinaryResponse($content, $contentType),
+            Task::OBJECT_DETECTION => new StructuredResponse(ObjectDetectionResult::fromArray($content)),
+            Task::QUESTION_ANSWERING => new StructuredResponse(QuestionAnsweringResult::fromArray($content)),
+            Task::SENTENCE_SIMILARITY => new StructuredResponse(SentenceSimilarityResult::fromArray($content)),
+            Task::SUMMARIZATION => new TextResponse($content[0]['summary_text']),
+            Task::TABLE_QUESTION_ANSWERING => new StructuredResponse(TableQuestionAnsweringResult::fromArray(dump($content))),
+            Task::TOKEN_CLASSIFICATION => new StructuredResponse(TokenClassificationResult::fromArray($content)),
+            Task::TRANSLATION => new TextResponse($content[0]['translation_text'] ?? ''),
+            Task::ZERO_SHOT_CLASSIFICATION => new StructuredResponse(ZeroShotClassificationResult::fromArray($content)),
+
+            default => throw new \RuntimeException(sprintf('Unsupported task: %s', $task)),
+        };
+    }
+}

--- a/src/Bridge/HuggingFace/Task.php
+++ b/src/Bridge/HuggingFace/Task.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Bridge\HuggingFace;
+
+interface Task
+{
+    public const AUDIO_CLASSIFICATION = 'audio-classification';
+    public const AUTOMATIC_SPEECH_RECOGNITION = 'automatic-speech-recognition';
+    public const CHAT_COMPLETION = 'chat-completion';
+    public const FEATURE_EXTRACTION = 'feature-extraction';
+    public const FILL_MASK = 'fill-mask';
+    public const IMAGE_CLASSIFICATION = 'image-classification';
+    public const IMAGE_SEGMENTATION = 'image-segmentation';
+    public const IMAGE_TO_TEXT = 'image-to-text';
+    public const OBJECT_DETECTION = 'object-detection';
+    public const QUESTION_ANSWERING = 'question-answering';
+    public const SENTENCE_SIMILARITY = 'sentence-similarity';
+    public const SUMMARIZATION = 'summarization';
+    public const TABLE_QUESTION_ANSWERING = 'table-question-answering';
+    public const TEXT_CLASSIFICATION = 'text-classification';
+    public const TEXT_GENERATION = 'text-generation';
+    public const TEXT_TO_IMAGE = 'text-to-image';
+    public const TOKEN_CLASSIFICATION = 'token-classification';
+    public const TRANSLATION = 'translation';
+    public const ZERO_SHOT_CLASSIFICATION = 'zero-shot-classification';
+}

--- a/src/Model/Response/BinaryResponse.php
+++ b/src/Model/Response/BinaryResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Model\Response;
+
+final class BinaryResponse implements ResponseInterface
+{
+    public function __construct(
+        public string $data,
+        public ?string $mimeType = null,
+    ) {
+    }
+
+    public function getContent(): string
+    {
+        return $this->data;
+    }
+
+    public function toBase64(): string
+    {
+        return \base64_encode($this->data);
+    }
+
+    public function toDataUri(): string
+    {
+        if (null === $this->mimeType) {
+            throw new \RuntimeException('Mime type is not set.');
+        }
+
+        return 'data:'.$this->mimeType.';base64,'.$this->toBase64();
+    }
+}

--- a/tests/Bridge/HuggingFace/ModelClientTest.php
+++ b/tests/Bridge/HuggingFace/ModelClientTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Bridge\HuggingFace;
+
+use PhpLlm\LlmChain\Bridge\HuggingFace\Model;
+use PhpLlm\LlmChain\Bridge\HuggingFace\ModelClient;
+use PhpLlm\LlmChain\Bridge\HuggingFace\Task;
+use PhpLlm\LlmChain\Model\Message\Content\Image;
+use PhpLlm\LlmChain\Model\Message\Content\Text;
+use PhpLlm\LlmChain\Model\Message\MessageBag;
+use PhpLlm\LlmChain\Model\Message\UserMessage;
+use PhpLlm\LlmChain\Model\Model as BaseModel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+#[CoversClass(ModelClient::class)]
+final class ModelClientTest extends TestCase
+{
+    public function testSupportsWithHuggingFaceModel(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+        $model = new Model('test-model');
+
+        self::assertTrue($modelClient->supports($model, 'test-input'));
+    }
+
+    public function testSupportsWithNonHuggingFaceModel(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+        $model = $this->createMock(BaseModel::class);
+
+        self::assertFalse($modelClient->supports($model, 'test-input'));
+    }
+
+    public function testRequestWithUnsupportedInputType(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+        $model = new Model('test-model');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported input type: stdClass');
+
+        $modelClient->request($model, new \stdClass());
+    }
+
+    public function testRequestWithNonHuggingFaceModel(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+        $model = $this->createMock(BaseModel::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $modelClient->request($model, 'test input');
+    }
+
+    #[DataProvider('urlTestCases')]
+    public function testGetUrlForDifferentInputsAndTasks(object|array|string $input, ?string $task, string $expectedUrl): void
+    {
+        $reflection = new \ReflectionClass(ModelClient::class);
+        $getUrlMethod = $reflection->getMethod('getUrl');
+        $getUrlMethod->setAccessible(true);
+
+        $model = new Model('test-model');
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+
+        $actualUrl = $getUrlMethod->invoke($modelClient, $model, $input, $task);
+
+        self::assertEquals($expectedUrl, $actualUrl);
+    }
+
+    public static function urlTestCases(): \Iterator
+    {
+        $messageBag = new MessageBag();
+        $messageBag->add(new UserMessage(new Text('Test message')));
+        yield 'string input' => [
+            'input' => 'Hello world',
+            'task' => null,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model',
+        ];
+        yield 'array input' => [
+            'input' => ['text' => 'Hello world'],
+            'task' => null,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model',
+        ];
+        yield 'image input' => [
+            'input' => Image::fromDataUrl('data:image/jpeg;base64,/9j/Cg=='),
+            'task' => null,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model',
+        ];
+        yield 'feature extraction' => [
+            'input' => 'Extract features',
+            'task' => Task::FEATURE_EXTRACTION,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/pipeline/feature-extraction/test-model',
+        ];
+        yield 'message bag' => [
+            'input' => $messageBag,
+            'task' => null,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model/v1/chat/completions',
+        ];
+    }
+
+    #[DataProvider('payloadTestCases')]
+    public function testGetPayloadForDifferentInputsAndTasks(object|array|string $input, ?string $task, array $options, array $expectedKeys, array $expectedValues = []): void
+    {
+        $reflection = new \ReflectionClass(ModelClient::class);
+        $getPayloadMethod = $reflection->getMethod('getPayload');
+        $getPayloadMethod->setAccessible(true);
+
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+
+        $payload = $getPayloadMethod->invoke($modelClient, $input, $options);
+
+        // Check that expected keys exist
+        foreach ($expectedKeys as $key) {
+            self::assertArrayHasKey($key, $payload);
+        }
+
+        // Check expected values if specified
+        foreach ($expectedValues as $path => $value) {
+            $keys = explode('.', $path);
+            $current = $payload;
+            foreach ($keys as $key) {
+                self::assertArrayHasKey($key, $current);
+                $current = $current[$key];
+            }
+
+            self::assertEquals($value, $current);
+        }
+    }
+
+    public static function payloadTestCases(): \Iterator
+    {
+        $messageBag = new MessageBag();
+        $messageBag->add(new UserMessage(new Text('Test message')));
+        yield 'string input' => [
+            'input' => 'Hello world',
+            'task' => null,
+            'options' => [],
+            'expectedKeys' => ['headers', 'json'],
+            'expectedValues' => [
+                'headers.Content-Type' => 'application/json',
+                'json.inputs' => 'Hello world',
+            ],
+        ];
+        yield 'array input' => [
+            'input' => ['text' => 'Hello world'],
+            'task' => null,
+            'options' => ['temperature' => 0.7],
+            'expectedKeys' => ['headers', 'json'],
+            'expectedValues' => [
+                'headers.Content-Type' => 'application/json',
+                'json.inputs' => ['text' => 'Hello world'],
+                'json.parameters.temperature' => 0.7,
+            ],
+        ];
+        yield 'message bag' => [
+            'input' => $messageBag,
+            'task' => null,
+            'options' => ['max_tokens' => 100],
+            'expectedKeys' => ['headers', 'json'],
+            'expectedValues' => [
+                'headers.Content-Type' => 'application/json',
+                'json.max_tokens' => 100,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
* 1st Commit: Christopher
* 2nd Commit: Claude Desktop with Jetbrains MCP:
  > I'm writing a PHP library that is similar to langchain but should also cover the HuggingFace inference API - like their library.
You can access my terminal and my IDE via tools.
Please have a look at the different tasks that should be available in src/Bridge/HuggingFace/Task.php and see the example implementation in examples/huggingface/text-classification.php in combination with the namespace PhpLlm\LlmChain\Bridge\HuggingFace.
Your task is to implement the response conversion, corresponding DTOs and examples for all other tasks than text-classification.
* 3rd Commit: Claude Desktop with Jetbrains MCP:
  > please have a look at the other examples in the examples/ folder using audio, image or text input and refactor the ones you just created.
all new example files are located in /home/christopher/Projects/PHP-LLM/llm-chain/examples/huggingface - please verify they're working by executing them - and patch bugs if there are any
* 4th Commit: Claude Desktop with Jetbrains MCP:
  > please create an example runner for huggingface examples, based on the /example file in root directory
* 5th Commit: Christopher making it work.