### PR TITLE
fix: missing namespace when upserting in Pinecone store

### DIFF
--- a/src/Bridge/Pinecone/Store.php
+++ b/src/Bridge/Pinecone/Store.php
@@ -40,7 +40,7 @@ final readonly class Store implements VectorStoreInterface
             return;
         }
 
-        $this->getVectors()->upsert($vectors);
+        $this->getVectors()->upsert($vectors, $this->namespace);
     }
 
     public function query(Vector $vector, array $options = [], ?float $minScore = null): array


### PR DESCRIPTION
When adding documents, it does not take configured namespace into consideration, this PR fixes it.