### PR TITLE
feat: add option to keep tool messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,34 @@ $eventDispatcher->addListener(ToolCallsExecuted::class, function (ToolCallsExecu
 });
 ```
 
+#### Keeping Tool Messages
+
+Sometimes you might wish to keep the tool messages (`AssistantMessage` containing the `toolCalls` and `ToolCallMessage` containing the response) in the context.
+Enable the `keepToolMessages` flag of the toolbox' `ChainProcessor` to ensure those messages will be added to your `MessageBag`.
+
+```php
+use PhpLlm\LlmChain\Chain\Toolbox\ChainProcessor;
+use PhpLlm\LlmChain\Chain\Toolbox\Toolbox;
+
+// Platform & LLM instantiation
+$messages = new MessageBag(
+    Message::forSystem(<<<PROMPT
+        Please answer all user questions only using the similary_search tool. Do not add information and if you cannot
+        find an answer, say so.
+        PROMPT),
+    Message::ofUser('...') // The user's question.
+);
+
+$yourTool = new YourTool();
+
+$toolbox = Toolbox::create($yourTool);
+$toolProcessor = new ChainProcessor($toolbox, keepToolMessages: true);
+
+$chain = new Chain($platform, $llm, inputProcessor: [$toolProcessor], outputProcessor: [$toolProcessor]);
+$response = $chain->call($messages);
+// $messages will now include the tool messages
+```
+
 #### Code Examples (with built-in tools)
 
 1. [Brave Tool](examples/toolbox/brave.php)

--- a/src/Chain/Toolbox/ChainProcessor.php
+++ b/src/Chain/Toolbox/ChainProcessor.php
@@ -33,6 +33,7 @@ final class ChainProcessor implements InputProcessorInterface, OutputProcessorIn
         private readonly ToolboxInterface $toolbox,
         private readonly ToolResultConverter $resultConverter = new ToolResultConverter(),
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
+        private readonly bool $keepToolMessages = false,
     ) {
     }
 
@@ -86,7 +87,7 @@ final class ChainProcessor implements InputProcessorInterface, OutputProcessorIn
     private function handleToolCallsCallback(Output $output): \Closure
     {
         return function (ToolCallResponse $response, ?AssistantMessage $streamedAssistantResponse = null) use ($output): ResponseInterface {
-            $messages = clone $output->messages;
+            $messages = $this->keepToolMessages ? $output->messages : clone $output->messages;
 
             if (null !== $streamedAssistantResponse && '' !== $streamedAssistantResponse->content) {
                 $messages->add($streamedAssistantResponse);


### PR DESCRIPTION
Adds an option to the Toolbox/ChainProcessor to keep tool messages by avoiding to clone the original messageBag

Fixes #321