### PR TITLE
test: to mock the ChainInterface we need to skip broken PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5.13",
         "probots-io/pinecone-php": "^1.0",
         "rector/rector": "^2.0",
         "symfony/console": "^6.4 || ^7.1",


### PR DESCRIPTION
Follows up on #323 