### PR TITLE
[DeepSeek][Tools] Allow to change URL for OpenAI  GPT using base_url configuration option

### DIFF
--- a/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
+++ b/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
@@ -35,7 +35,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof GPT;
     }
 
-    public function request(Model $model, array|object|string $input, array $options = []): ResponseInterface
+    public function request(Model $model, array|string $payload, array $options = []): ResponseInterface
     {
         $base_url = $model->getOptions()['base_url'] ?? 'https://api.openai.com/v1';
         $chat_completions_url = $model->getOptions()['chat_completions_url'] ?? '/chat/completions';
@@ -45,10 +45,7 @@ final readonly class ModelClient implements PlatformResponseFactory
             "{$base_url}{$chat_completions_url}",
             [
                 'auth_bearer' => $this->apiKey,
-                'json' => array_merge($options, [
-                    'model' => $model->getVersion(),
-                    'messages' => $input,
-                ]),
+                'json' => array_merge($options, $payload),
             ]
         );
     }

--- a/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
+++ b/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
@@ -36,9 +36,15 @@ final readonly class ModelClient implements PlatformResponseFactory
 
     public function request(Model $model, array|string $payload, array $options = []): ResponseInterface
     {
-        return $this->httpClient->request('POST', 'https://api.openai.com/v1/chat/completions', [
-            'auth_bearer' => $this->apiKey,
-            'json' => array_merge($options, $payload),
-        ]);
+        $base_url = $model->getOptions()['base_url'] ?? 'https://api.openai.com/v1';        
+        $chat_completions_url = $model->getOptions()['chat_completions_url'] ?? '/chat/completions';        
+        return $this->httpClient->request(
+            'POST', 
+            "{$base_url}{$chat_completions_url}", 
+            [
+                'auth_bearer' => $this->apiKey,
+                'json' => array_merge($options, $payload),
+            ]
+        );
     }
 }

--- a/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
+++ b/src/Platform/Bridge/OpenAI/GPT/ModelClient.php
@@ -30,7 +30,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         Assert::startsWith($apiKey, 'sk-', 'The API key must start with "sk-".');
     }
 
-    public function supports(Model $model, array|object|string $input): bool
+    public function supports(Model $model): bool
     {
         return $model instanceof GPT;
     }


### PR DESCRIPTION
DeepSeek now support function calling https://api-docs.deepseek.com/guides/function_calling

```php
<?php // config/packages/lim_chain.php

use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    $containerConfigurator->extension('llm_chain', [
        'platform' => [ 'openai' => [ 'api_key' => '%env(DEEPSEEK_API_KEY)%']],
        'chain' => [
            'default' => [
                'model' => [
                    'name' => 'GPT', // keep it
                    'version' => '%env(DEEPSEEK_API_MODEL)%', // 'deepseek-chat'
                    'options' => [
                        'base_url' => '%env(DEEPSEEK_API_URL)%', // 'https://api.deepseek.com'
                    ],
                ],
                'system_prompt' => 'You are a helpful assistant and you can provide the current date and time.',
            ],
        ],
    ]);
};
```

```php
<?php // src/AI/Tool/Clock.php
declare(strict_types=1);

namespace App\AI\Tool;

use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
use Symfony\Component\Clock\ClockInterface;
use Symfony\Component\Clock\NativeClock;

#[AsTool('clock', description: 'Provides the current date and time with time zone.')]
final readonly class Clock
{
    public function __construct(
        private ClockInterface $clock = new NativeClock(),
    ) {
    }

    public function __invoke(): string
    {
        return sprintf(
            'Current date is %s (YYYY-MM-DD) and the time is %s (HH:MM:SS) and time zone is %s.',
            $this->clock->now()->format('Y-m-d'),
            $this->clock->now()->format('H:i:s'),
            $this->clock->now()->getTimezone()->getName(), // for correct result needs the time zone !!!
        );
    }
}

```
### Using Tools – quite definitely!!!

<img width="698" alt="Screenshot 2025-06-15 at 20 52 17" src="https://github.com/user-attachments/assets/d9a0d5dc-19fa-4c29-96fc-6991663b314e" />

<img width="981" alt="Screenshot 2025-06-15 at 20 52 04" src="https://github.com/user-attachments/assets/951fe3a2-3303-474d-abc8-705811c8d2b9" />


### Without tools – hallucinating!!! 

<img width="712" alt="Screenshot 2025-06-15 at 19 27 17" src="https://github.com/user-attachments/assets/4e7ff358-e677-44ca-b542-8e55e5da49fd" />

<img width="1000" alt="Screenshot 2025-06-15 at 19 26 58" src="https://github.com/user-attachments/assets/4cdf8f38-fe51-4b8b-a392-2ff64d166ae9" />



