### PR TITLE
feat: add ResponseContract handling [by Claude Code]

### DIFF
--- a/src/Platform/Bridge/Mistral/PlatformFactory.php
+++ b/src/Platform/Bridge/Mistral/PlatformFactory.php
@@ -8,9 +8,12 @@ use PhpLlm\LlmChain\Platform\Bridge\Mistral\Contract\ToolNormalizer;
 use PhpLlm\LlmChain\Platform\Bridge\Mistral\Embeddings\ModelClient as EmbeddingsModelClient;
 use PhpLlm\LlmChain\Platform\Bridge\Mistral\Embeddings\ResponseConverter as EmbeddingsResponseConverter;
 use PhpLlm\LlmChain\Platform\Bridge\Mistral\Llm\ModelClient as MistralModelClient;
-use PhpLlm\LlmChain\Platform\Bridge\Mistral\Llm\ResponseConverter as MistralResponseConverter;
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\ResponseContract\MistralResponseParser;
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\ResponseContract\MistralStreamParser;
 use PhpLlm\LlmChain\Platform\Contract;
+use PhpLlm\LlmChain\Platform\Contract\ResponseDenormalizer;
 use PhpLlm\LlmChain\Platform\Platform;
+use PhpLlm\LlmChain\Platform\ResponseContract;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -28,7 +31,15 @@ final class PlatformFactory
 
         return new Platform(
             [new EmbeddingsModelClient($httpClient, $apiKey), new MistralModelClient($httpClient, $apiKey)],
-            [new EmbeddingsResponseConverter(), new MistralResponseConverter()],
+            [
+                new EmbeddingsResponseConverter(),
+                (new ResponseContract(
+                    new ResponseDenormalizer(
+                        new MistralResponseParser(),
+                        new MistralStreamParser(),
+                    )
+                ))->asConverter(),
+            ],
             Contract::create(new ToolNormalizer()),
         );
     }

--- a/src/Platform/Bridge/Mistral/ResponseContract/MistralResponseParser.php
+++ b/src/Platform/Bridge/Mistral/ResponseContract/MistralResponseParser.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Bridge\Mistral\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\ModelContractDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\Response\Choice;
+use PhpLlm\LlmChain\Platform\Response\ChoiceResponse;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\Response\ToolCall;
+use PhpLlm\LlmChain\Platform\Response\ToolCallResponse;
+
+final class MistralResponseParser extends ModelContractDenormalizer
+{
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Mistral;
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): LlmResponse
+    {
+        if (!isset($data['choices'])) {
+            throw new \RuntimeException('Invalid Mistral response structure: missing choices');
+        }
+
+        $choices = array_map([$this, 'parseChoice'], $data['choices']);
+
+        // For single choice responses, determine response type based on content
+        if (1 === \count($choices)) {
+            $choice = $choices[0];
+
+            if ($choice->hasToolCall()) {
+                return new ToolCallResponse(...$choice->getToolCalls());
+            }
+
+            return new TextResponse($choice->getContent() ?? '');
+        }
+
+        // Multiple choices always return ChoiceResponse
+        return new ChoiceResponse(...$choices);
+    }
+
+    /**
+     * @param array<string, mixed> $choice
+     */
+    private function parseChoice(array $choice): Choice
+    {
+        $message = $choice['message'] ?? [];
+
+        return new Choice(
+            content: $message['content'] ?? null,
+            toolCalls: array_map([$this, 'parseToolCall'], $message['tool_calls'] ?? []),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $toolCall
+     */
+    private function parseToolCall(array $toolCall): ToolCall
+    {
+        return new ToolCall(
+            id: $toolCall['id'],
+            name: $toolCall['function']['name'],
+            arguments: json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return LlmResponse::class === $type && parent::supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [LlmResponse::class => false];
+    }
+}

--- a/src/Platform/Bridge/Mistral/ResponseContract/MistralStreamParser.php
+++ b/src/Platform/Bridge/Mistral/ResponseContract/MistralStreamParser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Bridge\Mistral\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\ModelContractDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+
+final class MistralStreamParser extends ModelContractDenormalizer
+{
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Mistral;
+    }
+
+    /**
+     * @return array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool}
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): array
+    {
+        $choice = $data['choices'][0] ?? [];
+        $delta = $choice['delta'] ?? [];
+
+        return [
+            'textDelta' => $delta['content'] ?? null,
+            'toolCallDeltas' => $this->parseToolCallDeltas($delta['tool_calls'] ?? []),
+            'finishReason' => $choice['finish_reason'] ?? null,
+            'isDone' => false, // Mistral uses '[DONE]' signal which is handled by the stream denormalizer
+        ];
+    }
+
+    /**
+     * @param array<int, array{id?: string, function?: array{name?: string, arguments?: string}}> $toolCalls
+     *
+     * @return array<int, array{id?: string, name?: string, arguments?: string}>
+     */
+    private function parseToolCallDeltas(array $toolCalls): array
+    {
+        $deltas = [];
+
+        foreach ($toolCalls as $i => $toolCall) {
+            $delta = [];
+
+            if (isset($toolCall['id'])) {
+                $delta['id'] = $toolCall['id'];
+            }
+
+            if (isset($toolCall['function']['name'])) {
+                $delta['name'] = $toolCall['function']['name'];
+            }
+
+            if (isset($toolCall['function']['arguments'])) {
+                $delta['arguments'] = $toolCall['function']['arguments'];
+            }
+
+            if (!empty($delta)) {
+                $deltas[$i] = $delta;
+            }
+        }
+
+        return $deltas;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return 'stream_chunk' === $type && parent::supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['stream_chunk' => false];
+    }
+}

--- a/src/Platform/Bridge/OpenAI/PlatformFactory.php
+++ b/src/Platform/Bridge/OpenAI/PlatformFactory.php
@@ -8,12 +8,15 @@ use PhpLlm\LlmChain\Platform\Bridge\OpenAI\DallE\ModelClient as DallEModelClient
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Embeddings\ModelClient as EmbeddingsModelClient;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Embeddings\ResponseConverter as EmbeddingsResponseConverter;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT\ModelClient as GPTModelClient;
-use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT\ResponseConverter as GPTResponseConverter;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIResponseParser;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIStreamParser;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Whisper\AudioNormalizer;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Whisper\ModelClient as WhisperModelClient;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Whisper\ResponseConverter as WhisperResponseConverter;
 use PhpLlm\LlmChain\Platform\Contract;
+use PhpLlm\LlmChain\Platform\Contract\ResponseDenormalizer;
 use PhpLlm\LlmChain\Platform\Platform;
+use PhpLlm\LlmChain\Platform\ResponseContract;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -39,7 +42,12 @@ final readonly class PlatformFactory
                 new WhisperModelClient($httpClient, $apiKey),
             ],
             [
-                new GPTResponseConverter(),
+                (new ResponseContract(
+                    new ResponseDenormalizer(
+                        new OpenAIResponseParser(),
+                        new OpenAIStreamParser(),
+                    )
+                ))->asConverter(),
                 new EmbeddingsResponseConverter(),
                 $dallEModelClient,
                 new WhisperResponseConverter(),

--- a/src/Platform/Bridge/OpenAI/ResponseContract/OpenAIResponseParser.php
+++ b/src/Platform/Bridge/OpenAI/ResponseContract/OpenAIResponseParser.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\ModelContractDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\Response\Choice;
+use PhpLlm\LlmChain\Platform\Response\ChoiceResponse;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\Response\ToolCall;
+use PhpLlm\LlmChain\Platform\Response\ToolCallResponse;
+
+final class OpenAIResponseParser extends ModelContractDenormalizer
+{
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof GPT;
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): LlmResponse
+    {
+        if (!isset($data['choices'])) {
+            throw new \RuntimeException('Invalid OpenAI response structure: missing choices');
+        }
+
+        $choices = array_map([$this, 'parseChoice'], $data['choices']);
+
+        // For single choice responses, determine response type based on content
+        if (1 === \count($choices)) {
+            $choice = $choices[0];
+
+            if ($choice->hasToolCall()) {
+                return new ToolCallResponse(...$choice->getToolCalls());
+            }
+
+            return new TextResponse($choice->getContent() ?? '');
+        }
+
+        // Multiple choices always return ChoiceResponse
+        return new ChoiceResponse(...$choices);
+    }
+
+    /**
+     * @param array<string, mixed> $choice
+     */
+    private function parseChoice(array $choice): Choice
+    {
+        $message = $choice['message'] ?? [];
+
+        return new Choice(
+            content: $message['content'] ?? null,
+            toolCalls: array_map([$this, 'parseToolCall'], $message['tool_calls'] ?? []),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $toolCall
+     */
+    private function parseToolCall(array $toolCall): ToolCall
+    {
+        return new ToolCall(
+            id: $toolCall['id'],
+            name: $toolCall['function']['name'],
+            arguments: json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return LlmResponse::class === $type && parent::supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [LlmResponse::class => false];
+    }
+}

--- a/src/Platform/Bridge/OpenAI/ResponseContract/OpenAIStreamParser.php
+++ b/src/Platform/Bridge/OpenAI/ResponseContract/OpenAIStreamParser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\ModelContractDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+
+final class OpenAIStreamParser extends ModelContractDenormalizer
+{
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof GPT;
+    }
+
+    /**
+     * @return array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool}
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): array
+    {
+        $choice = $data['choices'][0] ?? [];
+        $delta = $choice['delta'] ?? [];
+
+        return [
+            'textDelta' => $delta['content'] ?? null,
+            'toolCallDeltas' => $this->parseToolCallDeltas($delta['tool_calls'] ?? []),
+            'finishReason' => $choice['finish_reason'] ?? null,
+            'isDone' => false, // OpenAI uses '[DONE]' signal which is handled by the stream denormalizer
+        ];
+    }
+
+    /**
+     * @param array<int, array{id?: string, function?: array{name?: string, arguments?: string}}> $toolCalls
+     *
+     * @return array<int, array{id?: string, name?: string, arguments?: string}>
+     */
+    private function parseToolCallDeltas(array $toolCalls): array
+    {
+        $deltas = [];
+
+        foreach ($toolCalls as $i => $toolCall) {
+            $delta = [];
+
+            if (isset($toolCall['id'])) {
+                $delta['id'] = $toolCall['id'];
+            }
+
+            if (isset($toolCall['function']['name'])) {
+                $delta['name'] = $toolCall['function']['name'];
+            }
+
+            if (isset($toolCall['function']['arguments'])) {
+                $delta['arguments'] = $toolCall['function']['arguments'];
+            }
+
+            if (!empty($delta)) {
+                $deltas[$i] = $delta;
+            }
+        }
+
+        return $deltas;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return 'stream_chunk' === $type && parent::supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['stream_chunk' => false];
+    }
+}

--- a/src/Platform/Contract/Denormalizer/ModelContractDenormalizer.php
+++ b/src/Platform/Contract/Denormalizer/ModelContractDenormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Contract\Denormalizer;
+
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+abstract class ModelContractDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    abstract protected function supportsModel(Model $model): bool;
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        if (isset($context[ResponseContract::CONTEXT_MODEL]) && $context[ResponseContract::CONTEXT_MODEL] instanceof Model) {
+            return $this->supportsModel($context[ResponseContract::CONTEXT_MODEL]);
+        }
+
+        return false;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['*' => false];
+    }
+}

--- a/src/Platform/Contract/Denormalizer/StreamResponseDenormalizer.php
+++ b/src/Platform/Contract/Denormalizer/StreamResponseDenormalizer.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Contract\Denormalizer;
+
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\StreamResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class StreamResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): LlmResponse
+    {
+        $response = $context[ResponseContract::CONTEXT_HTTP_RESPONSE];
+
+        return new StreamResponse($this->createStreamGenerator($response, $context));
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function createStreamGenerator(ResponseInterface $response, array $context): \Generator
+    {
+        $toolCalls = [];
+        $textBuffer = '';
+
+        try {
+            foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
+                if (!$chunk instanceof ServerSentEvent) {
+                    continue;
+                }
+
+                if ('[DONE]' === $chunk->getData()) {
+                    break;
+                }
+
+                try {
+                    $data = $chunk->getArrayData();
+                } catch (\JsonException) {
+                    continue;
+                }
+
+                /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $streamChunk */
+                $streamChunk = $this->denormalizer->denormalize(
+                    $data,
+                    'stream_chunk',
+                    null,
+                    $context
+                );
+
+                if ($streamChunk['textDelta']) {
+                    $textBuffer .= $streamChunk['textDelta'];
+                    yield $streamChunk['textDelta'];
+                }
+
+                $toolCalls = $this->accumulateToolCalls($toolCalls, $streamChunk['toolCallDeltas']);
+
+                if ($streamChunk['isDone']) {
+                    break;
+                }
+            }
+        } catch (HttpExceptionInterface) {
+            // Stream ended or error occurred
+        }
+    }
+
+    /**
+     * @param array<int, array{id?: string, name?: string, arguments?: string}> $toolCalls
+     * @param array<int, array{id?: string, name?: string, arguments?: string}> $deltas
+     *
+     * @return array<int, array{id?: string, name?: string, arguments?: string}>
+     */
+    private function accumulateToolCalls(array $toolCalls, array $deltas): array
+    {
+        foreach ($deltas as $i => $delta) {
+            if (isset($delta['id'])) {
+                // Initialize tool call
+                $toolCalls[$i] = [
+                    'id' => $delta['id'],
+                    'name' => $delta['name'] ?? '',
+                    'arguments' => $delta['arguments'] ?? '',
+                ];
+                continue;
+            }
+
+            // Add arguments delta to tool call
+            if (isset($toolCalls[$i]) && isset($delta['arguments'])) {
+                $toolCalls[$i]['arguments'] .= $delta['arguments'];
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return LlmResponse::class === $type && ($context[ResponseContract::CONTEXT_OPTIONS]['stream'] ?? false);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [LlmResponse::class => false];
+    }
+}

--- a/src/Platform/Contract/Denormalizer/TextResponseDenormalizer.php
+++ b/src/Platform/Contract/Denormalizer/TextResponseDenormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Contract\Denormalizer;
+
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class TextResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): LlmResponse
+    {
+        // Delegate to the platform-specific parser, which now returns the final Response object directly
+        return $this->denormalizer->denormalize($data, LlmResponse::class, $format, $context);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return LlmResponse::class === $type && !($context[ResponseContract::CONTEXT_OPTIONS]['stream'] ?? false);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [LlmResponse::class => false];
+    }
+}

--- a/src/Platform/Contract/ResponseDenormalizer.php
+++ b/src/Platform/Contract/ResponseDenormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform\Contract;
+
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\StreamResponseDenormalizer;
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\TextResponseDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+final class ResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    private readonly Serializer $serializer;
+
+    public function __construct(DenormalizerInterface ...$denormalizers)
+    {
+        $this->serializer = new Serializer([
+            ...$denormalizers,
+            // Base denormalizers
+            new TextResponseDenormalizer(),
+            new StreamResponseDenormalizer(),
+        ]);
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        return $this->serializer->denormalize($data, $type, $format, $context);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $this->serializer->supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return $this->serializer->getSupportedTypes($format);
+    }
+}

--- a/src/Platform/ResponseContract.php
+++ b/src/Platform/ResponseContract.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform;
+
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final readonly class ResponseContract
+{
+    public const CONTEXT_MODEL = 'llm_model';
+    public const CONTEXT_OPTIONS = 'llm_options';
+    public const CONTEXT_HTTP_RESPONSE = 'http_response';
+
+    public function __construct(
+        private DenormalizerInterface $denormalizer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function convertResponse(
+        Model $model,
+        ResponseInterface $response,
+        array $options = [],
+    ): LlmResponse {
+        $context = [
+            self::CONTEXT_MODEL => $model,
+            self::CONTEXT_OPTIONS => $options,
+            self::CONTEXT_HTTP_RESPONSE => $response,
+        ];
+
+        return $this->denormalizer->denormalize(
+            $response->toArray(false),
+            LlmResponse::class,
+            null,
+            $context
+        );
+    }
+
+    public function asConverter(): ResponseConverterInterface
+    {
+        return new ResponseContractFactory($this);
+    }
+
+    public function supportsModel(Model $model): bool
+    {
+        // Check if any denormalizer supports this model by testing denormalization
+        $context = [self::CONTEXT_MODEL => $model];
+
+        return $this->denormalizer->supportsDenormalization([], LlmResponse::class, null, $context);
+    }
+}

--- a/src/Platform/ResponseContractFactory.php
+++ b/src/Platform/ResponseContractFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Platform;
+
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResponseContractFactory implements ResponseConverterInterface
+{
+    private ?Model $currentModel = null;
+
+    public function __construct(
+        private readonly ResponseContract $responseContract,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        // Store the model temporarily for the next convert() call (cleared after use)
+        $this->currentModel = $model;
+
+        // Check if any of the registered denormalizers support this model
+        return $this->responseContract->supportsModel($model);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function convert(ResponseInterface $response, array $options = []): LlmResponse
+    {
+        if (!$this->currentModel) {
+            throw new \InvalidArgumentException('Model must be provided via supports() call first');
+        }
+
+        $model = $this->currentModel;
+        $this->currentModel = null; // Clear state after use to prevent unexpected reuse
+
+        return $this->responseContract->convertResponse(
+            $model,
+            $response,
+            $options
+        );
+    }
+}

--- a/tests/Platform/Bridge/Mistral/ResponseContract/MistralResponseParserTest.php
+++ b/tests/Platform/Bridge/Mistral/ResponseContract/MistralResponseParserTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform\Bridge\Mistral\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\ResponseContract\MistralResponseParser;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\Response\ToolCallResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MistralResponseParser::class)]
+final class MistralResponseParserTest extends TestCase
+{
+    private MistralResponseParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new MistralResponseParser();
+    }
+
+    public function testSupportsMistralModel(): void
+    {
+        $mistralModel = new Mistral(Mistral::MISTRAL_SMALL);
+        $context = [ResponseContract::CONTEXT_MODEL => $mistralModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDoesNotSupportNonMistralModel(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        $context = [ResponseContract::CONTEXT_MODEL => $gptModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertFalse($result);
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        $mistralModel = new Mistral(Mistral::MISTRAL_SMALL);
+        $context = [ResponseContract::CONTEXT_MODEL => $mistralModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDenormalizeSimpleTextResponse(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Bonjour, comment puis-je vous aider?',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+            'usage' => [
+                'prompt_tokens' => 12,
+                'completion_tokens' => 8,
+                'total_tokens' => 20,
+            ],
+            'model' => 'mistral-small-latest',
+            'id' => 'cmpl-mistral-123',
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new Mistral(Mistral::MISTRAL_SMALL)];
+        $result = $this->parser->denormalize($responseData, LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(TextResponse::class, $result);
+        self::assertSame('Bonjour, comment puis-je vous aider?', $result->getContent());
+    }
+
+    public function testDenormalizeResponseWithToolCalls(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_mistral_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location": "Paris", "unit": "celsius"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new Mistral(Mistral::MISTRAL_SMALL)];
+        $result = $this->parser->denormalize($responseData, LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(ToolCallResponse::class, $result);
+        $toolCalls = $result->getContent();
+        self::assertCount(1, $toolCalls);
+
+        $toolCall = $toolCalls[0];
+        self::assertSame('call_mistral_123', $toolCall->id);
+        self::assertSame('get_weather', $toolCall->name);
+        self::assertSame(['location' => 'Paris', 'unit' => 'celsius'], $toolCall->arguments);
+    }
+
+    public function testDenormalizeThrowsExceptionForInvalidStructure(): void
+    {
+        $invalidData = ['invalid' => 'structure'];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid Mistral response structure: missing choices');
+
+        $context = [ResponseContract::CONTEXT_MODEL => new Mistral(Mistral::MISTRAL_SMALL)];
+        $this->parser->denormalize($invalidData, LlmResponse::class, null, $context);
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        $supportedTypes = $this->parser->getSupportedTypes(null);
+
+        self::assertSame([LlmResponse::class => false], $supportedTypes);
+    }
+}

--- a/tests/Platform/Bridge/OpenAI/ResponseContract/OpenAIResponseParserTest.php
+++ b/tests/Platform/Bridge/OpenAI/ResponseContract/OpenAIResponseParserTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform\Bridge\OpenAI\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIResponseParser;
+use PhpLlm\LlmChain\Platform\Response\ChoiceResponse;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\Response\ToolCallResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpenAIResponseParser::class)]
+final class OpenAIResponseParserTest extends TestCase
+{
+    private OpenAIResponseParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new OpenAIResponseParser();
+    }
+
+    public function testSupportsGPTModel(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        $context = [ResponseContract::CONTEXT_MODEL => $gptModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDoesNotSupportNonGPTModel(): void
+    {
+        $mistralModel = new Mistral(Mistral::MISTRAL_SMALL);
+        $context = [ResponseContract::CONTEXT_MODEL => $mistralModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertFalse($result);
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        $context = [ResponseContract::CONTEXT_MODEL => $gptModel];
+
+        $result = $this->parser->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDenormalizeSimpleTextResponse(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello, how can I help you?',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 7,
+                'total_tokens' => 17,
+            ],
+            'model' => 'gpt-4o-mini',
+            'id' => 'chatcmpl-123',
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        $result = $this->parser->denormalize($responseData, LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(TextResponse::class, $result);
+        self::assertSame('Hello, how can I help you?', $result->getContent());
+    }
+
+    public function testDenormalizeResponseWithToolCalls(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location": "London", "unit": "celsius"}',
+                                ],
+                            ],
+                            [
+                                'id' => 'call_456',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_time',
+                                    'arguments' => '{"timezone": "UTC"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        $result = $this->parser->denormalize($responseData, LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(ToolCallResponse::class, $result);
+        $toolCalls = $result->getContent();
+        self::assertCount(2, $toolCalls);
+
+        // First tool call
+        $firstToolCall = $toolCalls[0];
+        self::assertSame('call_123', $firstToolCall->id);
+        self::assertSame('get_weather', $firstToolCall->name);
+        self::assertSame(['location' => 'London', 'unit' => 'celsius'], $firstToolCall->arguments);
+
+        // Second tool call
+        $secondToolCall = $toolCalls[1];
+        self::assertSame('call_456', $secondToolCall->id);
+        self::assertSame('get_time', $secondToolCall->name);
+        self::assertSame(['timezone' => 'UTC'], $secondToolCall->arguments);
+    }
+
+    public function testDenormalizeMultipleChoicesResponse(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'First choice',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Second choice',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 1,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        $result = $this->parser->denormalize($responseData, LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(ChoiceResponse::class, $result);
+        $choices = $result->getContent();
+        self::assertCount(2, $choices);
+
+        self::assertSame('First choice', $choices[0]->getContent());
+        self::assertSame('Second choice', $choices[1]->getContent());
+    }
+
+    public function testDenormalizeThrowsExceptionForInvalidStructure(): void
+    {
+        $invalidData = ['invalid' => 'structure'];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid OpenAI response structure: missing choices');
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        $this->parser->denormalize($invalidData, LlmResponse::class, null, $context);
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        $supportedTypes = $this->parser->getSupportedTypes(null);
+
+        self::assertSame([LlmResponse::class => false], $supportedTypes);
+    }
+}

--- a/tests/Platform/Bridge/OpenAI/ResponseContract/OpenAIStreamParserTest.php
+++ b/tests/Platform/Bridge/OpenAI/ResponseContract/OpenAIStreamParserTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform\Bridge\OpenAI\ResponseContract;
+
+use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIStreamParser;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpenAIStreamParser::class)]
+final class OpenAIStreamParserTest extends TestCase
+{
+    private OpenAIStreamParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new OpenAIStreamParser();
+    }
+
+    public function testSupportsGPTModel(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        $context = [ResponseContract::CONTEXT_MODEL => $gptModel];
+
+        $result = $this->parser->supportsDenormalization([], 'stream_chunk', null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDoesNotSupportNonGPTModel(): void
+    {
+        $mistralModel = new Mistral(Mistral::MISTRAL_SMALL);
+        $context = [ResponseContract::CONTEXT_MODEL => $mistralModel];
+
+        $result = $this->parser->supportsDenormalization([], 'stream_chunk', null, $context);
+
+        self::assertFalse($result);
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        $context = [ResponseContract::CONTEXT_MODEL => $gptModel];
+
+        $result = $this->parser->supportsDenormalization([], 'stream_chunk', null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDenormalizeTextStreamChunk(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [
+                        'content' => 'Hello world',
+                    ],
+                    'finish_reason' => null,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertSame('Hello world', $result['textDelta']);
+        self::assertEmpty($result['toolCallDeltas']);
+        self::assertNull($result['finishReason']);
+        self::assertFalse($result['isDone']);
+    }
+
+    public function testDenormalizeStreamChunkWithFinishReason(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertNull($result['textDelta']);
+        self::assertEmpty($result['toolCallDeltas']);
+        self::assertSame('stop', $result['finishReason']);
+        self::assertFalse($result['isDone']);
+    }
+
+    public function testDenormalizeToolCallStreamChunk(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location"',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => null,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertNull($result['textDelta']);
+        self::assertNull($result['finishReason']);
+        self::assertFalse($result['isDone']);
+
+        self::assertCount(1, $result['toolCallDeltas']);
+        $toolCallDelta = $result['toolCallDeltas'][0];
+        self::assertSame('call_123', $toolCallDelta['id']);
+        self::assertSame('get_weather', $toolCallDelta['name']);
+        self::assertSame('{"location"', $toolCallDelta['arguments']);
+    }
+
+    public function testDenormalizeToolCallStreamChunkArguments(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [
+                        'tool_calls' => [
+                            [
+                                'function' => [
+                                    'arguments' => ': "London"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => null,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertNull($result['textDelta']);
+        self::assertNull($result['finishReason']);
+        self::assertFalse($result['isDone']);
+
+        self::assertCount(1, $result['toolCallDeltas']);
+        $toolCallDelta = $result['toolCallDeltas'][0];
+        self::assertArrayNotHasKey('id', $toolCallDelta);
+        self::assertArrayNotHasKey('name', $toolCallDelta);
+        self::assertSame(': "London"}', $toolCallDelta['arguments']);
+    }
+
+    public function testDenormalizeMultipleToolCallsStreamChunk(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_1',
+                                'function' => [
+                                    'name' => 'function_1',
+                                    'arguments' => '{"arg1"',
+                                ],
+                            ],
+                            [
+                                'function' => [
+                                    'arguments' => ': "value1"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => null,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertCount(2, $result['toolCallDeltas']);
+
+        // First tool call (new)
+        $firstDelta = $result['toolCallDeltas'][0];
+        self::assertSame('call_1', $firstDelta['id']);
+        self::assertSame('function_1', $firstDelta['name']);
+        self::assertSame('{"arg1"', $firstDelta['arguments']);
+
+        // Second tool call (continuation)
+        $secondDelta = $result['toolCallDeltas'][1];
+        self::assertArrayNotHasKey('id', $secondDelta);
+        self::assertArrayNotHasKey('name', $secondDelta);
+        self::assertSame(': "value1"}', $secondDelta['arguments']);
+    }
+
+    public function testDenormalizeEmptyStreamChunk(): void
+    {
+        $streamData = [
+            'choices' => [
+                [
+                    'delta' => [],
+                    'finish_reason' => null,
+                ],
+            ],
+        ];
+
+        $context = [ResponseContract::CONTEXT_MODEL => new GPT(GPT::GPT_4O_MINI)];
+        /** @var array{textDelta: ?string, toolCallDeltas: array<int, array{id?: string, name?: string, arguments?: string}>, finishReason: ?string, isDone: bool} $result */
+        $result = $this->parser->denormalize($streamData, 'stream_chunk', null, $context);
+
+        self::assertNull($result['textDelta']);
+        self::assertEmpty($result['toolCallDeltas']);
+        self::assertNull($result['finishReason']);
+        self::assertFalse($result['isDone']);
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        $supportedTypes = $this->parser->getSupportedTypes(null);
+
+        self::assertSame(['stream_chunk' => false], $supportedTypes);
+    }
+}

--- a/tests/Platform/Contract/Denormalizer/StreamResponseDenormalizerTest.php
+++ b/tests/Platform/Contract/Denormalizer/StreamResponseDenormalizerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform\Contract\Denormalizer;
+
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\StreamResponseDenormalizer;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\Response\StreamResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+#[CoversClass(StreamResponseDenormalizer::class)]
+final class StreamResponseDenormalizerTest extends TestCase
+{
+    private StreamResponseDenormalizer $denormalizer;
+
+    protected function setUp(): void
+    {
+        $this->denormalizer = new StreamResponseDenormalizer();
+        $mockDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $this->denormalizer->setDenormalizer($mockDenormalizer);
+    }
+
+    public function testSupportsDenormalizationForStreamingResponse(): void
+    {
+        $context = [ResponseContract::CONTEXT_OPTIONS => ['stream' => true]];
+
+        $result = $this->denormalizer->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDoesNotSupportDenormalizationForNonStreamingResponse(): void
+    {
+        $context = [ResponseContract::CONTEXT_OPTIONS => []];
+
+        $result = $this->denormalizer->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertFalse($result);
+    }
+
+    public function testDenormalizeStreamResponse(): void
+    {
+        $mockHttpClient = new MockHttpClient();
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test', [
+            'body' => 'data: {"choices":[{"delta":{"content":"Hello"}}]}'."\n\n".
+                'data: [DONE]'."\n\n",
+            'headers' => ['content-type' => 'text/event-stream'],
+        ]);
+
+        $context = [
+            ResponseContract::CONTEXT_HTTP_RESPONSE => $mockResponse,
+            ResponseContract::CONTEXT_OPTIONS => ['stream' => true],
+        ];
+
+        $result = $this->denormalizer->denormalize([], LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(StreamResponse::class, $result);
+
+        // Verify it returns a generator
+        $content = $result->getContent();
+        self::assertInstanceOf(\Generator::class, $content);
+    }
+
+    public function testDenormalizeStreamResponseWithToolCalls(): void
+    {
+        $mockHttpClient = new MockHttpClient();
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test', [
+            'body' => 'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_123"}]}}]}'."\n\n".
+                'data: [DONE]'."\n\n",
+            'headers' => ['content-type' => 'text/event-stream'],
+        ]);
+
+        $context = [
+            ResponseContract::CONTEXT_HTTP_RESPONSE => $mockResponse,
+            ResponseContract::CONTEXT_OPTIONS => ['stream' => true],
+        ];
+
+        $result = $this->denormalizer->denormalize([], LlmResponse::class, null, $context);
+
+        self::assertInstanceOf(StreamResponse::class, $result);
+
+        // Verify it returns a generator
+        $content = $result->getContent();
+        self::assertInstanceOf(\Generator::class, $content);
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        $supportedTypes = $this->denormalizer->getSupportedTypes(null);
+
+        self::assertSame([LlmResponse::class => false], $supportedTypes);
+    }
+}

--- a/tests/Platform/Contract/Denormalizer/TextResponseDenormalizerTest.php
+++ b/tests/Platform/Contract/Denormalizer/TextResponseDenormalizerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform\Contract\Denormalizer;
+
+use PhpLlm\LlmChain\Platform\Contract\Denormalizer\TextResponseDenormalizer;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface as LlmResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TextResponseDenormalizer::class)]
+final class TextResponseDenormalizerTest extends TestCase
+{
+    private TextResponseDenormalizer $denormalizer;
+
+    protected function setUp(): void
+    {
+        $this->denormalizer = new TextResponseDenormalizer();
+    }
+
+    public function testSupportsDenormalizationForNonStreamingResponse(): void
+    {
+        $context = [ResponseContract::CONTEXT_OPTIONS => []];
+
+        $result = $this->denormalizer->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertTrue($result);
+    }
+
+    public function testDoesNotSupportDenormalizationForStreamingResponse(): void
+    {
+        $context = [ResponseContract::CONTEXT_OPTIONS => ['stream' => true]];
+
+        $result = $this->denormalizer->supportsDenormalization([], LlmResponse::class, null, $context);
+
+        self::assertFalse($result);
+    }
+
+    public function testGetSupportedTypes(): void
+    {
+        $supportedTypes = $this->denormalizer->getSupportedTypes(null);
+
+        self::assertSame([LlmResponse::class => false], $supportedTypes);
+    }
+}

--- a/tests/Platform/ResponseContractFactoryTest.php
+++ b/tests/Platform/ResponseContractFactoryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform;
+
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIResponseParser;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIStreamParser;
+use PhpLlm\LlmChain\Platform\Contract\ResponseDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PhpLlm\LlmChain\Platform\ResponseContractFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(ResponseContractFactory::class)]
+final class ResponseContractFactoryTest extends TestCase
+{
+    private ResponseContractFactory $factory;
+    private Model $model;
+
+    protected function setUp(): void
+    {
+        $responseContract = new ResponseContract(
+            new ResponseDenormalizer(
+                new OpenAIResponseParser(),
+                new OpenAIStreamParser(),
+            )
+        );
+        $this->factory = new ResponseContractFactory($responseContract);
+        $this->model = new GPT(GPT::GPT_4O_MINI);
+    }
+
+    public function testSupportsModel(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        self::assertTrue($this->factory->supports($gptModel));
+    }
+
+    public function testConvert(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Test response',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(json_encode($responseData))]);
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test');
+
+        // First call supports() to set the model
+        $this->factory->supports($this->model);
+
+        // Then call convert()
+        $response = $this->factory->convert($mockResponse);
+
+        self::assertInstanceOf(TextResponse::class, $response);
+        self::assertSame('Test response', $response->getContent());
+    }
+
+    public function testConvertWithoutSupportsCallThrowsException(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Test response',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(json_encode($responseData))]);
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model must be provided via supports() call first');
+
+        $this->factory->convert($mockResponse);
+    }
+
+    public function testStateIsClearedAfterConvert(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'First response',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse(json_encode($responseData)),
+            new MockResponse(json_encode($responseData)),
+        ]);
+        $firstResponse = $mockHttpClient->request('GET', 'https://api.test');
+        $secondResponse = $mockHttpClient->request('GET', 'https://api.test');
+
+        // First call: supports() + convert() should work
+        $this->factory->supports($this->model);
+        $result = $this->factory->convert($firstResponse);
+        self::assertInstanceOf(TextResponse::class, $result);
+
+        // Second call: convert() without supports() should fail (state was cleared)
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model must be provided via supports() call first');
+
+        $this->factory->convert($secondResponse);
+    }
+}

--- a/tests/Platform/ResponseContractTest.php
+++ b/tests/Platform/ResponseContractTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\LlmChain\Tests\Platform;
+
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIResponseParser;
+use PhpLlm\LlmChain\Platform\Bridge\OpenAI\ResponseContract\OpenAIStreamParser;
+use PhpLlm\LlmChain\Platform\Contract\ResponseDenormalizer;
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\Response\TextResponse;
+use PhpLlm\LlmChain\Platform\Response\ToolCallResponse;
+use PhpLlm\LlmChain\Platform\ResponseContract;
+use PhpLlm\LlmChain\Platform\ResponseContractFactory;
+use PhpLlm\LlmChain\Platform\ResponseConverterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(ResponseContract::class)]
+final class ResponseContractTest extends TestCase
+{
+    private ResponseContract $responseContract;
+    private Model $model;
+
+    protected function setUp(): void
+    {
+        $this->responseContract = new ResponseContract(
+            new ResponseDenormalizer(
+                new OpenAIResponseParser(),
+                new OpenAIStreamParser(),
+            )
+        );
+        $this->model = new GPT(GPT::GPT_4O_MINI);
+    }
+
+    public function testCreateResponseContract(): void
+    {
+        $contract = new ResponseContract(
+            new ResponseDenormalizer(
+                new OpenAIResponseParser(),
+                new OpenAIStreamParser(),
+            )
+        );
+
+        self::assertInstanceOf(ResponseContract::class, $contract);
+    }
+
+    public function testAsConverter(): void
+    {
+        $converter = $this->responseContract->asConverter();
+
+        self::assertInstanceOf(ResponseConverterInterface::class, $converter);
+        self::assertInstanceOf(ResponseContractFactory::class, $converter);
+    }
+
+    public function testSupportsModel(): void
+    {
+        $gptModel = new GPT(GPT::GPT_4O_MINI);
+        self::assertTrue($this->responseContract->supportsModel($gptModel));
+    }
+
+    public function testConvertResponseSimpleText(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello, how can I help you?',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(json_encode($responseData))]);
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test');
+        $response = $this->responseContract->convertResponse($this->model, $mockResponse);
+
+        self::assertInstanceOf(TextResponse::class, $response);
+        self::assertSame('Hello, how can I help you?', $response->getContent());
+    }
+
+    public function testConvertResponseWithToolCalls(): void
+    {
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location": "London"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(json_encode($responseData))]);
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test');
+        $response = $this->responseContract->convertResponse($this->model, $mockResponse);
+
+        self::assertInstanceOf(ToolCallResponse::class, $response);
+        $toolCalls = $response->getContent();
+        self::assertCount(1, $toolCalls);
+        self::assertSame('call_123', $toolCalls[0]->id);
+        self::assertSame('get_weather', $toolCalls[0]->name);
+        self::assertSame(['location' => 'London'], $toolCalls[0]->arguments);
+    }
+
+    public function testConvertResponseWithStreamOption(): void
+    {
+        // For the context test, we'll mock a basic response with streaming option
+        $responseData = [
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello world',
+                    ],
+                    'finish_reason' => 'stop',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(
+            json_encode($responseData),
+            ['content-type' => 'application/json']
+        )]);
+        $mockResponse = $mockHttpClient->request('GET', 'https://api.test');
+
+        // Test that the ResponseContract passes through the options correctly
+        $response = $this->responseContract->convertResponse(
+            $this->model,
+            $mockResponse,
+            ['stream' => false] // Actually test non-streaming
+        );
+
+        self::assertInstanceOf(TextResponse::class, $response);
+        self::assertSame('Hello world', $response->getContent());
+    }
+
+    public function testResponseContractConstants(): void
+    {
+        self::assertSame('llm_model', ResponseContract::CONTEXT_MODEL);
+        self::assertSame('llm_options', ResponseContract::CONTEXT_OPTIONS);
+        self::assertSame('http_response', ResponseContract::CONTEXT_HTTP_RESPONSE);
+    }
+}


### PR DESCRIPTION
**Input:**
> When you look at the different implementations of ResponseConverterInterface in the various Platform\Bridge namespace, there is a lot of redundancies. I would think, that similar with
   the Contract handling with the Normalizers, it is somehow possible to abstract away the response conversion into DTOs so we can share behavior of conversion between the 
  implementations. especially around tool call and stream handling.