### PR TITLE
refactor!: rename `Capability::OUTPUT_STRUCTURED` to `STRUCTURED_OUTPUT`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,37 @@
+# Upgrade Guide
+
+## Breaking Changes
+
+### Capability Constant Rename
+
+The capability constant `Capability::OUTPUT_STRUCTURED` has been renamed to `Capability::STRUCTURED_OUTPUT` to follow a more consistent naming pattern.
+
+Additionally, the constant value has been changed from `'output-structured'` to `'structured-output'`.
+
+#### Before
+```php
+use PhpLlm\LlmChain\Platform\Capability;
+
+// Constant name
+Capability::OUTPUT_STRUCTURED
+
+// Constant value
+'output-structured'
+```
+
+#### After
+```php
+use PhpLlm\LlmChain\Platform\Capability;
+
+// Constant name
+Capability::STRUCTURED_OUTPUT
+
+// Constant value
+'structured-output'
+```
+
+#### Migration
+
+Update all references in your code from `Capability::OUTPUT_STRUCTURED` to `Capability::STRUCTURED_OUTPUT`.
+
+If you're storing or comparing capability strings directly, also update from `'output-structured'` to `'structured-output'`.

--- a/src/Chain/StructuredOutput/ChainProcessor.php
+++ b/src/Chain/StructuredOutput/ChainProcessor.php
@@ -46,7 +46,7 @@ final class ChainProcessor implements InputProcessorInterface, OutputProcessorIn
             return;
         }
 
-        if (!$input->model->supports(Capability::OUTPUT_STRUCTURED)) {
+        if (!$input->model->supports(Capability::STRUCTURED_OUTPUT)) {
             throw MissingModelSupportException::forStructuredOutput($input->model::class);
         }
 

--- a/src/Platform/Bridge/Google/Gemini.php
+++ b/src/Platform/Bridge/Google/Gemini.php
@@ -29,7 +29,7 @@ class Gemini extends Model
             Capability::INPUT_AUDIO,
             Capability::INPUT_PDF,
             Capability::OUTPUT_STREAMING,
-            Capability::OUTPUT_STRUCTURED,
+            Capability::STRUCTURED_OUTPUT,
             Capability::TOOL_CALLING,
         ];
 

--- a/src/Platform/Bridge/Mistral/Mistral.php
+++ b/src/Platform/Bridge/Mistral/Mistral.php
@@ -34,7 +34,7 @@ final class Mistral extends Model
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,
             Capability::OUTPUT_STREAMING,
-            Capability::OUTPUT_STRUCTURED,
+            Capability::STRUCTURED_OUTPUT,
         ];
 
         if (\in_array($name, [self::PIXSTRAL, self::PIXSTRAL_LARGE, self::MISTRAL_SMALL], true)) {

--- a/src/Platform/Bridge/OpenAI/GPT.php
+++ b/src/Platform/Bridge/OpenAI/GPT.php
@@ -75,7 +75,7 @@ class GPT extends Model
         }
 
         if (\in_array($name, self::STRUCTURED_OUTPUT_SUPPORTING, true)) {
-            $capabilities[] = Capability::OUTPUT_STRUCTURED;
+            $capabilities[] = Capability::STRUCTURED_OUTPUT;
         }
 
         parent::__construct($name, $capabilities, $options);

--- a/src/Platform/Capability.php
+++ b/src/Platform/Capability.php
@@ -21,7 +21,7 @@ class Capability
     public const OUTPUT_AUDIO = 'output-audio';
     public const OUTPUT_IMAGE = 'output-image';
     public const OUTPUT_STREAMING = 'output-streaming';
-    public const OUTPUT_STRUCTURED = 'output-structured';
+    public const STRUCTURED_OUTPUT = 'structured-output';
     public const OUTPUT_TEXT = 'output-text';
 
     // FUNCTIONALITY

--- a/tests/Chain/StructuredOutput/ChainProcessorTest.php
+++ b/tests/Chain/StructuredOutput/ChainProcessorTest.php
@@ -40,7 +40,7 @@ final class ChainProcessorTest extends TestCase
     {
         $chainProcessor = new ChainProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
-        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $model = new Model('gpt-4', [Capability::STRUCTURED_OUTPUT]);
         $input = new Input($model, new MessageBag(), ['output_structure' => 'SomeStructure']);
 
         $chainProcessor->processInput($input);
@@ -53,7 +53,7 @@ final class ChainProcessorTest extends TestCase
     {
         $chainProcessor = new ChainProcessor(new ConfigurableResponseFormatFactory());
 
-        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $model = new Model('gpt-4', [Capability::STRUCTURED_OUTPUT]);
         $input = new Input($model, new MessageBag(), []);
 
         $chainProcessor->processInput($input);
@@ -79,7 +79,7 @@ final class ChainProcessorTest extends TestCase
     {
         $chainProcessor = new ChainProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
-        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $model = new Model('gpt-4', [Capability::STRUCTURED_OUTPUT]);
         $options = ['output_structure' => SomeStructure::class];
         $input = new Input($model, new MessageBag(), $options);
         $chainProcessor->processInput($input);
@@ -100,7 +100,7 @@ final class ChainProcessorTest extends TestCase
     {
         $chainProcessor = new ChainProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
-        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $model = new Model('gpt-4', [Capability::STRUCTURED_OUTPUT]);
         $options = ['output_structure' => MathReasoning::class];
         $input = new Input($model, new MessageBag(), $options);
         $chainProcessor->processInput($input);


### PR DESCRIPTION
## Summary

- Renamed the capability constant `OUTPUT_STRUCTURED` to `STRUCTURED_OUTPUT` for better naming consistency
- Changed the constant value from `'output-structured'` to `'structured-output'`
- Added UPGRADE.md documentation for the breaking change

## Breaking Change

This is a breaking change that requires users to update their code:
- All references to `Capability::OUTPUT_STRUCTURED` must be changed to `Capability::STRUCTURED_OUTPUT`
- If storing or comparing capability strings directly, update from `'output-structured'` to `'structured-output'`

## Test plan

- [x] All tests pass with the renamed constant
- [x] Updated all references in the codebase (6 files)
- [x] Added upgrade documentation

🤖 Generated with [Claude Code](https://claude.ai/code)