### PR TITLE
fix: resolve array tool arguments

### DIFF
--- a/src/Chain/Toolbox/ToolCallArgumentResolver.php
+++ b/src/Chain/Toolbox/ToolCallArgumentResolver.php
@@ -28,7 +28,8 @@ final readonly class ToolCallArgumentResolver implements ToolCallArgumentResolve
         $arguments = [];
 
         foreach ($toolCall->arguments as $name => $value) {
-            $arguments[$name] = $this->denormalizer->denormalize($value, (string) $parameters[$name]->getType());
+            $parameterType = (string) $parameters[$name]->getType();
+            $arguments[$name] = 'array' === $parameterType ? $value : $this->denormalizer->denormalize($value, $parameterType);
         }
 
         return $arguments;

--- a/tests/Chain/Toolbox/ToolCallArgumentResolverTest.php
+++ b/tests/Chain/Toolbox/ToolCallArgumentResolverTest.php
@@ -6,6 +6,7 @@ use PhpLlm\LlmChain\Chain\Toolbox\ToolCallArgumentResolver;
 use PhpLlm\LlmChain\Platform\Response\ToolCall;
 use PhpLlm\LlmChain\Platform\Tool\ExecutionReference;
 use PhpLlm\LlmChain\Platform\Tool\Tool;
+use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolArray;
 use PhpLlm\LlmChain\Tests\Fixture\Tool\ToolDate;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -28,5 +29,25 @@ class ToolCallArgumentResolverTest extends TestCase
         $toolCall = new ToolCall('invocation', 'tool_date', ['date' => '2025-06-29']);
 
         self::assertEquals(['date' => new \DateTimeImmutable('2025-06-29')], $resolver->resolveArguments($tool, $metadata, $toolCall));
+    }
+
+    #[Test]
+    public function resolveScalarArrayArguments(): void
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $tool = new ToolArray();
+        $metadata = new Tool(new ExecutionReference(ToolArray::class, '__invoke'), 'tool_array', 'A tool with array parameters');
+        $toolCall = new ToolCall('tool_id_1234', 'tool_array', [
+            'urls' => ['https://symfony.com', 'https://php.net'],
+            'ids' => [1, 2, 3],
+        ]);
+
+        $expected = [
+            'urls' => ['https://symfony.com', 'https://php.net'],
+            'ids' => [1, 2, 3],
+        ];
+
+        self::assertSame($expected, $resolver->resolveArguments($tool, $metadata, $toolCall));
     }
 }

--- a/tests/Fixture/Tool/ToolArray.php
+++ b/tests/Fixture/Tool/ToolArray.php
@@ -6,7 +6,7 @@ namespace PhpLlm\LlmChain\Tests\Fixture\Tool;
 
 use PhpLlm\LlmChain\Chain\Toolbox\Attribute\AsTool;
 
-#[AsTool('tool_no_params', 'A tool without parameters')]
+#[AsTool('tool_array', 'A tool with array parameters')]
 final class ToolArray
 {
     /**


### PR DESCRIPTION
@valtzu any idea about this case?

found it after merging #359 with example [examples/toolbox/tavily.php](https://github.com/php-llm/llm-chain/blob/main/examples/toolbox/tavily.php)

patch feels a bit hacky, but does the job atm