### PR TITLE
feat: allow JsonSerializable objects in contract

### DIFF
--- a/src/Platform/Contract.php
+++ b/src/Platform/Contract.php
@@ -17,6 +17,7 @@ use PhpLlm\LlmChain\Platform\Contract\Normalizer\Response\ToolCallNormalizer;
 use PhpLlm\LlmChain\Platform\Contract\Normalizer\ToolNormalizer;
 use PhpLlm\LlmChain\Platform\Tool\Tool;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Serializer;
 
@@ -52,6 +53,9 @@ final readonly class Contract
 
         // Response
         $normalizer[] = new ToolCallNormalizer();
+
+        // JsonSerializable objects as extension point to library interfaces
+        $normalizer[] = new JsonSerializableNormalizer();
 
         return new self(
             new Serializer($normalizer),


### PR DESCRIPTION
As brought up in #371 it could be a possible extension point to the contract to reintroduce the support for `JsonSerializable` objects when there are no normalizers for an object. 

So it would be a possible alternative for custom `MessageBagInterface`, `MessageInterface`, `ContentInterface`, etc. by allowing them to implement the `JsonSerializable` interface.

