### PR TITLE
fix: Gemini system prompt

### DIFF
--- a/src/Platform/Bridge/Google/Contract/MessageBagNormalizer.php
+++ b/src/Platform/Bridge/Google/Contract/MessageBagNormalizer.php
@@ -37,7 +37,7 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
      *          role: 'model'|'user',
      *          parts: array<int, mixed>
      *      }>,
-     *      system_instruction?: array{parts: array{text: string}}
+     *      system_instruction?: array{parts: array{text: string}[]}
      *  }
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
@@ -46,7 +46,7 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
 
         if (null !== $systemMessage = $data->getSystemMessage()) {
             $array['system_instruction'] = [
-                'parts' => ['text' => $systemMessage->content],
+                'parts' => [['text' => $systemMessage->content]],
             ];
         }
 

--- a/tests/Platform/Bridge/Google/Contract/MessageBagNormalizerTest.php
+++ b/tests/Platform/Bridge/Google/Contract/MessageBagNormalizerTest.php
@@ -142,7 +142,7 @@ final class MessageBagNormalizerTest extends TestCase
                     ['role' => 'user', 'parts' => [['text' => 'Hello there']]],
                 ],
                 'system_instruction' => [
-                    'parts' => ['text' => 'You are a cat. Your name is Neko.'],
+                    'parts' => [['text' => 'You are a cat. Your name is Neko.']],
                 ],
             ],
         ];


### PR DESCRIPTION
I started to getting 400 Bad Request, not sure if it was due to changing a model or what. Changing `system_instructions` into an array like in the [docs](https://ai.google.dev/gemini-api/docs/text-generation#system-instructions) fixed it.

Tested at least with `gemini-1.5-pro` and `gemini-2.5-pro` and `gemini-2.0-flash`, works fine.