### PR TITLE
refactor: replace composer suggests with runtime checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,19 +63,6 @@
         "symfony/process": "^6.4 || ^7.1",
         "symfony/var-dumper": "^6.4 || ^7.1"
     },
-    "suggest": {
-        "ext-pdo": "For using MariaDB as retrieval vector store.",
-        "async-aws/bedrock-runtime": "For using the Bedrock platform.",
-        "codewithkyrian/chromadb-php": "For using the ChromaDB as retrieval vector store.",
-        "codewithkyrian/transformers": "For using the TransformersPHP with FFI to run models in PHP.",
-        "doctrine/dbal": "For using MariaDB via Doctrine as retrieval vector store",
-        "mongodb/mongodb": "For using MongoDB Atlas as retrieval vector store.",
-        "mrmysql/youtube-transcript": "For using the YouTube transcription tool.",
-        "probots-io/pinecone-php": "For using the Pinecone as retrieval vector store.",
-        "symfony/dom-crawler": "For using the Crawler tool.",
-        "symfony/http-foundation": "For using the SessionStore as message store.",
-        "psr/cache": "For using the CacheStore as message store."
-    },
     "config": {
         "allow-plugins": {
             "codewithkyrian/transformers-libsloader": true,

--- a/src/Chain/Chat/MessageStore/CacheStore.php
+++ b/src/Chain/Chat/MessageStore/CacheStore.php
@@ -17,7 +17,7 @@ final readonly class CacheStore implements MessageStoreInterface
         private int $ttl = 86400,
     ) {
         if (!interface_exists(CacheItemPoolInterface::class)) {
-            throw new \RuntimeException('For using the CacheStore as message store, the psr/cache package is required. Try running "composer require psr/cache"');
+            throw new \RuntimeException('For using the CacheStore as message store, the psr/cache package is required. Try running "composer require psr/cache".');
         }
     }
 

--- a/src/Chain/Chat/MessageStore/CacheStore.php
+++ b/src/Chain/Chat/MessageStore/CacheStore.php
@@ -16,6 +16,9 @@ final readonly class CacheStore implements MessageStoreInterface
         private string $cacheKey,
         private int $ttl = 86400,
     ) {
+        if (!interface_exists(CacheItemPoolInterface::class)) {
+            throw new \RuntimeException('For using the CacheStore as message store, the psr/cache package is required. Try running "composer require psr/cache"');
+        }
     }
 
     public function save(MessageBagInterface $messages): void

--- a/src/Chain/Chat/MessageStore/CacheStore.php
+++ b/src/Chain/Chat/MessageStore/CacheStore.php
@@ -17,7 +17,7 @@ final readonly class CacheStore implements MessageStoreInterface
         private int $ttl = 86400,
     ) {
         if (!interface_exists(CacheItemPoolInterface::class)) {
-            throw new \RuntimeException('For using the CacheStore as message store, the psr/cache package is required. Try running "composer require psr/cache".');
+            throw new \RuntimeException('For using the CacheStore as message store, a PSR-6 cache implementation is required. Try running "composer require symfony/cache" or another PSR-6 compatible cache.');
         }
     }
 

--- a/src/Chain/Chat/MessageStore/SessionStore.php
+++ b/src/Chain/Chat/MessageStore/SessionStore.php
@@ -18,6 +18,9 @@ final readonly class SessionStore implements MessageStoreInterface
         RequestStack $requestStack,
         private string $sessionKey = 'messages',
     ) {
+        if (!class_exists(RequestStack::class)) {
+            throw new \RuntimeException('For using the SessionStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation"');
+        }
         $this->session = $requestStack->getSession();
     }
 

--- a/src/Chain/Chat/MessageStore/SessionStore.php
+++ b/src/Chain/Chat/MessageStore/SessionStore.php
@@ -19,7 +19,7 @@ final readonly class SessionStore implements MessageStoreInterface
         private string $sessionKey = 'messages',
     ) {
         if (!class_exists(RequestStack::class)) {
-            throw new \RuntimeException('For using the SessionStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation"');
+            throw new \RuntimeException('For using the SessionStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation".');
         }
         $this->session = $requestStack->getSession();
     }

--- a/src/Chain/Toolbox/Tool/Crawler.php
+++ b/src/Chain/Toolbox/Tool/Crawler.php
@@ -19,7 +19,7 @@ final readonly class Crawler
         private HttpClientInterface $httpClient,
     ) {
         if (!class_exists(DomCrawler::class)) {
-            throw new RuntimeException('For using the Crawler tool, the symfony/dom-crawler package is required. Try running "composer require symfony/dom-crawler"');
+            throw new RuntimeException('For using the Crawler tool, the symfony/dom-crawler package is required. Try running "composer require symfony/dom-crawler".');
         }
     }
 

--- a/src/Chain/Toolbox/Tool/Crawler.php
+++ b/src/Chain/Toolbox/Tool/Crawler.php
@@ -19,7 +19,7 @@ final readonly class Crawler
         private HttpClientInterface $httpClient,
     ) {
         if (!class_exists(DomCrawler::class)) {
-            throw new RuntimeException('The DomCrawler component is not installed. Please install it using "composer require symfony/dom-crawler".');
+            throw new RuntimeException('For using the Crawler tool, the symfony/dom-crawler package is required. Try running "composer require symfony/dom-crawler"');
         }
     }
 

--- a/src/Chain/Toolbox/Tool/YouTubeTranscriber.php
+++ b/src/Chain/Toolbox/Tool/YouTubeTranscriber.php
@@ -20,7 +20,7 @@ final readonly class YouTubeTranscriber
         private HttpClientInterface $client,
     ) {
         if (!class_exists(TranscriptListFetcher::class)) {
-            throw new LogicException('For using the YouTube transcription tool, the mrmysql/youtube-transcript package is required. Try running "composer require mrmysql/youtube-transcript"');
+            throw new LogicException('For using the YouTube transcription tool, the mrmysql/youtube-transcript package is required. Try running "composer require mrmysql/youtube-transcript".');
         }
     }
 

--- a/src/Chain/Toolbox/Tool/YouTubeTranscriber.php
+++ b/src/Chain/Toolbox/Tool/YouTubeTranscriber.php
@@ -20,7 +20,7 @@ final readonly class YouTubeTranscriber
         private HttpClientInterface $client,
     ) {
         if (!class_exists(TranscriptListFetcher::class)) {
-            throw new LogicException('The package `mrmysql/youtube-transcript` is required to use this tool. Try running "composer require mrmysql/youtube-transcript".');
+            throw new LogicException('For using the YouTube transcription tool, the mrmysql/youtube-transcript package is required. Try running "composer require mrmysql/youtube-transcript"');
         }
     }
 

--- a/src/Platform/Bridge/Bedrock/PlatformFactory.php
+++ b/src/Platform/Bridge/Bedrock/PlatformFactory.php
@@ -19,6 +19,10 @@ final readonly class PlatformFactory
         BedrockRuntimeClient $bedrockRuntimeClient = new BedrockRuntimeClient(),
         ?Contract $contract = null,
     ): Platform {
+        if (!class_exists(BedrockRuntimeClient::class)) {
+            throw new \RuntimeException('For using the Bedrock platform, the async-aws/bedrock-runtime package is required. Try running "composer require async-aws/bedrock-runtime"');
+        }
+
         $modelClient[] = new ClaudeHandler($bedrockRuntimeClient);
         $modelClient[] = new NovaHandler($bedrockRuntimeClient);
         $modelClient[] = new LlamaModelClient($bedrockRuntimeClient);

--- a/src/Platform/Bridge/Bedrock/PlatformFactory.php
+++ b/src/Platform/Bridge/Bedrock/PlatformFactory.php
@@ -20,7 +20,7 @@ final readonly class PlatformFactory
         ?Contract $contract = null,
     ): Platform {
         if (!class_exists(BedrockRuntimeClient::class)) {
-            throw new \RuntimeException('For using the Bedrock platform, the async-aws/bedrock-runtime package is required. Try running "composer require async-aws/bedrock-runtime"');
+            throw new \RuntimeException('For using the Bedrock platform, the async-aws/bedrock-runtime package is required. Try running "composer require async-aws/bedrock-runtime".');
         }
 
         $modelClient[] = new ClaudeHandler($bedrockRuntimeClient);

--- a/src/Platform/Bridge/TransformersPHP/PlatformFactory.php
+++ b/src/Platform/Bridge/TransformersPHP/PlatformFactory.php
@@ -15,7 +15,7 @@ final readonly class PlatformFactory
     public static function create(): Platform
     {
         if (!class_exists(Transformers::class)) {
-            throw new RuntimeException('TransformersPHP is not installed. Please install it using "composer require codewithkyrian/transformers".');
+            throw new RuntimeException('For using the TransformersPHP with FFI to run models in PHP, the codewithkyrian/transformers package is required. Try running "composer require codewithkyrian/transformers"');
         }
 
         return new Platform();

--- a/src/Platform/Bridge/TransformersPHP/PlatformFactory.php
+++ b/src/Platform/Bridge/TransformersPHP/PlatformFactory.php
@@ -15,7 +15,7 @@ final readonly class PlatformFactory
     public static function create(): Platform
     {
         if (!class_exists(Transformers::class)) {
-            throw new RuntimeException('For using the TransformersPHP with FFI to run models in PHP, the codewithkyrian/transformers package is required. Try running "composer require codewithkyrian/transformers"');
+            throw new RuntimeException('For using the TransformersPHP with FFI to run models in PHP, the codewithkyrian/transformers package is required. Try running "composer require codewithkyrian/transformers".');
         }
 
         return new Platform();

--- a/src/Store/Bridge/ChromaDB/Store.php
+++ b/src/Store/Bridge/ChromaDB/Store.php
@@ -20,6 +20,9 @@ final readonly class Store implements VectorStoreInterface
         private Client $client,
         private string $collectionName,
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using the ChromaDB as retrieval vector store, the codewithkyrian/chromadb-php package is required. Try running "composer require codewithkyrian/chromadb-php"');
+        }
     }
 
     public function add(VectorDocument ...$documents): void

--- a/src/Store/Bridge/ChromaDB/Store.php
+++ b/src/Store/Bridge/ChromaDB/Store.php
@@ -21,7 +21,7 @@ final readonly class Store implements VectorStoreInterface
         private string $collectionName,
     ) {
         if (!class_exists(Client::class)) {
-            throw new \RuntimeException('For using the ChromaDB as retrieval vector store, the codewithkyrian/chromadb-php package is required. Try running "composer require codewithkyrian/chromadb-php"');
+            throw new \RuntimeException('For using the ChromaDB as retrieval vector store, the codewithkyrian/chromadb-php package is required. Try running "composer require codewithkyrian/chromadb-php".');
         }
     }
 

--- a/src/Store/Bridge/MariaDB/Store.php
+++ b/src/Store/Bridge/MariaDB/Store.php
@@ -34,7 +34,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private string $indexName,
         private string $vectorFieldName,
     ) {
-        if (!extension_loaded('pdo')) {
+        if (!\extension_loaded('pdo')) {
             throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension is required. Try running "composer require ext-pdo"');
         }
     }

--- a/src/Store/Bridge/MariaDB/Store.php
+++ b/src/Store/Bridge/MariaDB/Store.php
@@ -35,7 +35,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private string $vectorFieldName,
     ) {
         if (!\extension_loaded('pdo')) {
-            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension is required. Try running "composer require ext-pdo"');
+            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension needs to be enabled.');
         }
     }
 

--- a/src/Store/Bridge/MariaDB/Store.php
+++ b/src/Store/Bridge/MariaDB/Store.php
@@ -50,7 +50,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
     public static function fromDbal(Connection $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
     {
         if (!class_exists(Connection::class)) {
-            throw new \RuntimeException('For using MariaDB via Doctrine as retrieval vector store, the doctrine/dbal package is required. Try running "composer require doctrine/dbal"');
+            throw new \RuntimeException('For using MariaDB via Doctrine as retrieval vector store, the doctrine/dbal package is required. Try running "composer require doctrine/dbal".');
         }
 
         $pdo = $connection->getNativeConnection();

--- a/src/Store/Bridge/MariaDB/Store.php
+++ b/src/Store/Bridge/MariaDB/Store.php
@@ -50,7 +50,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
     public static function fromDbal(Connection $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
     {
         if (!class_exists(Connection::class)) {
-            throw new \RuntimeException('For using MariaDB via Doctrine as retrieval vector store, the doctrine/dbal package is required. Try running "composer require doctrine/dbal".');
+            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension needs to be enabled.');
         }
 
         $pdo = $connection->getNativeConnection();

--- a/src/Store/Bridge/MariaDB/Store.php
+++ b/src/Store/Bridge/MariaDB/Store.php
@@ -34,6 +34,9 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private string $indexName,
         private string $vectorFieldName,
     ) {
+        if (!extension_loaded('pdo')) {
+            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension is required. Try running "composer require ext-pdo"');
+        }
     }
 
     public static function fromPdo(\PDO $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
@@ -46,6 +49,10 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
      */
     public static function fromDbal(Connection $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
     {
+        if (!class_exists(Connection::class)) {
+            throw new \RuntimeException('For using MariaDB via Doctrine as retrieval vector store, the doctrine/dbal package is required. Try running "composer require doctrine/dbal"');
+        }
+
         $pdo = $connection->getNativeConnection();
 
         if (!$pdo instanceof \PDO) {

--- a/src/Store/Bridge/MongoDB/Store.php
+++ b/src/Store/Bridge/MongoDB/Store.php
@@ -59,6 +59,9 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private bool $bulkWrite = false,
         private LoggerInterface $logger = new NullLogger(),
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using MongoDB Atlas as retrieval vector store, the mongodb/mongodb package is required. Try running "composer require mongodb/mongodb"');
+        }
     }
 
     public function add(VectorDocument ...$documents): void

--- a/src/Store/Bridge/MongoDB/Store.php
+++ b/src/Store/Bridge/MongoDB/Store.php
@@ -60,7 +60,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private LoggerInterface $logger = new NullLogger(),
     ) {
         if (!class_exists(Client::class)) {
-            throw new \RuntimeException('For using MongoDB Atlas as retrieval vector store, the mongodb/mongodb package is required. Try running "composer require mongodb/mongodb"');
+            throw new \RuntimeException('For using MongoDB Atlas as retrieval vector store, the mongodb/mongodb package is required. Try running "composer require mongodb/mongodb".');
         }
     }
 

--- a/src/Store/Bridge/Pinecone/Store.php
+++ b/src/Store/Bridge/Pinecone/Store.php
@@ -26,6 +26,9 @@ final readonly class Store implements VectorStoreInterface
         private array $filter = [],
         private int $topK = 3,
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using the Pinecone as retrieval vector store, the probots-io/pinecone-php package is required. Try running "composer require probots-io/pinecone-php"');
+        }
     }
 
     public function add(VectorDocument ...$documents): void

--- a/src/Store/Bridge/Pinecone/Store.php
+++ b/src/Store/Bridge/Pinecone/Store.php
@@ -27,7 +27,7 @@ final readonly class Store implements VectorStoreInterface
         private int $topK = 3,
     ) {
         if (!class_exists(Client::class)) {
-            throw new \RuntimeException('For using the Pinecone as retrieval vector store, the probots-io/pinecone-php package is required. Try running "composer require probots-io/pinecone-php"');
+            throw new \RuntimeException('For using the Pinecone as retrieval vector store, the probots-io/pinecone-php package is required. Try running "composer require probots-io/pinecone-php".');
         }
     }
 


### PR DESCRIPTION
Remove the `suggest` section from composer.json and add explicit runtime checks
that throw exceptions with helpful composer require commands when optional
dependencies are missing.

This provides better developer experience by:
- Giving clear error messages when optional dependencies are needed
- Providing the exact composer command to install missing packages
- Following Symfony's pattern for handling optional dependencies

Optional dependencies now throw exceptions instead of
silently failing when the required packages are not installed.