### PR TITLE
chore: use PHPStan error identifier instead of regex pattern

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -11,6 +11,6 @@ parameters:
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -
-            message: '#no value type specified in iterable type array#'
+            identifier: missingType.iterableValue
             path: tests/*
 


### PR DESCRIPTION
## Summary

This PR updates the PHPStan configuration to use an error identifier instead of a regex pattern for ignoring array type errors in tests.

## Changes

- Replace regex pattern  with identifier 

## Benefits

Using error identifiers is the recommended approach because:
- **More stable**: Identifiers don't change across PHPStan versions, unlike error message text
- **Cleaner**: Easier to read and understand the intent
- **Maintainable**: Less prone to breaking if error message wording changes

## Testing

PHPStan analysis passes with the new configuration.